### PR TITLE
Updated noble-mac dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -866,8 +866,8 @@
       }
     },
     "noble-mac": {
-      "version": "git+https://github.com/Timeular/noble-mac.git#b2becff4f4d3c1e94b34fb75ad73c21fdfc29b39",
-      "from": "git+https://github.com/Timeular/noble-mac.git#b2becff",
+      "version": "git+https://github.com/Timeular/noble-mac.git#a776e9a5b66abeb45707559321e3007a0b397b48",
+      "from": "git+https://github.com/Timeular/noble-mac.git#a776e9a",
       "requires": {
         "cross-spawn": "^6.0.5",
         "napi-thread-safe-callback": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -368,6 +368,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -587,6 +599,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -809,6 +826,11 @@
         }
       }
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
     "noble": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/noble/-/noble-1.9.1.tgz",
@@ -844,9 +866,10 @@
       }
     },
     "noble-mac": {
-      "version": "git+ssh://git@github.com/Timeular/noble-mac.git#3d8046d330624e1d1c66fc4d6a3ed7598eba8f69",
-      "from": "git+ssh://git@github.com/Timeular/noble-mac.git#3d8046d",
+      "version": "git+https://github.com/Timeular/noble-mac.git#b2becff4f4d3c1e94b34fb75ad73c21fdfc29b39",
+      "from": "git+https://github.com/Timeular/noble-mac.git#b2becff",
       "requires": {
+        "cross-spawn": "^6.0.5",
         "napi-thread-safe-callback": "0.0.6",
         "noble": "^1.9.1",
         "node-addon-api": "^1.1.0",
@@ -972,6 +995,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -1146,6 +1174,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -1399,6 +1440,14 @@
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
       "integrity": "sha1-I1h4ejXakQMtrV6S+AsSNw2HlcU=",
       "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "noble": "1.9.1",
-    "noble-mac": "git@github.com:Timeular/noble-mac.git#3d8046d"
+    "noble-mac": "https://github.com/Timeular/noble-mac.git#b2becff"
   },
   "devDependencies": {
     "jsdoc-to-markdown": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "noble": "1.9.1",
-    "noble-mac": "https://github.com/Timeular/noble-mac.git#b2becff"
+    "noble-mac": "https://github.com/Timeular/noble-mac.git#a776e9a"
   },
   "devDependencies": {
     "jsdoc-to-markdown": "^4.0.1",


### PR DESCRIPTION
Updated noble-mac dependency to [PR version that I submitted to noble-mac](https://github.com/Timeular/noble-mac/pull/8) that will work correctly on Linux/Windows. The recent change to noble-mac broke node-poweredup on any non-Mac OS.

I've tested this fix on Linux. The Noble library doesn't work with my Windows Bluetooth adapter, but it should work the same there. I don't have access to Mac OS to test, but there shouldn't be any issue with Mac as well.