### PR TITLE
Minor refactoring for NPM/TypeScript package compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
-
+.vscode/
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,17 @@
+boostmovehub.ts
+consts.ts
+duplotrainbase.ts
+hub.ts
+index.ts
+lpf2hub.ts
+port.ts
+poweredup.ts
+puphub.ts
+pupremote.ts
+package-lock.json
+tsconfig.json
+tslint.json
+utils.ts
+wedo2smarthub.ts
+.vscode/
+examples/

--- a/index.ts
+++ b/index.ts
@@ -8,4 +8,4 @@ import { PUPRemote } from "./pupremote";
 import { WeDo2SmartHub } from "./wedo2smarthub";
 
 export default PoweredUP;
-export { Hub, WeDo2SmartHub, BoostMoveHub, PUPHub, PUPRemote, DuploTrainBase, Consts };
+export { PoweredUP, Hub, WeDo2SmartHub, BoostMoveHub, PUPHub, PUPRemote, DuploTrainBase, Consts };

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,11 @@
+import { BoostMoveHub } from "./boostmovehub";
+import * as Consts from "./consts";
+import { DuploTrainBase } from "./duplotrainbase";
+import { Hub } from "./hub";
+import { PoweredUP } from "./poweredup";
+import { PUPHub } from "./puphub";
+import { PUPRemote } from "./pupremote";
+import { WeDo2SmartHub } from "./wedo2smarthub";
+
+export default PoweredUP;
+export { Hub, WeDo2SmartHub, BoostMoveHub, PUPHub, PUPRemote, DuploTrainBase, Consts };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "node-poweredup",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/debug": {
       "version": "0.0.30",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/@/@types/debug/_attachments/debug-0.0.30.tgz",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
       "dev": true
     },
     "@types/events": {
       "version": "1.2.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/@/@types/events/_attachments/events-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
     "@types/noble": {
       "version": "0.0.37",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/@/@types/noble/_attachments/noble-0.0.37.tgz",
+      "resolved": "https://registry.npmjs.org/@types/noble/-/noble-0.0.37.tgz",
       "integrity": "sha512-1g/UifUgJXLaVv/7Q4YE1ppXYpkpafdTtgaZ9NubL6zzMXXaFrD+KAliyDnLh0Vur6f/JkxhB7i3kx4yD5hWKA==",
       "dev": true,
       "requires": {
@@ -34,7 +34,7 @@
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/abbrev/_attachments/abbrev-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "ansi-escape-sequences": {
@@ -48,23 +48,23 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/ansi-regex/_attachments/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/ansi-styles/_attachments/ansi-styles-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/aproba/_attachments/aproba-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/are-we-there-yet/_attachments/are-we-there-yet-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
         "delegates": "^1.0.0",
@@ -73,7 +73,7 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/argparse/_attachments/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
@@ -82,7 +82,7 @@
     },
     "argv-tools": {
       "version": "0.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/argv-tools/_attachments/argv-tools-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
       "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
       "dev": true,
       "requires": {
@@ -92,7 +92,7 @@
     },
     "array-back": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/array-back/_attachments/array-back-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "dev": true,
       "requires": {
@@ -101,7 +101,7 @@
     },
     "async": {
       "version": "2.6.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/a/async/_attachments/async-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
@@ -110,7 +110,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/b/babel-code-frame/_attachments/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -121,7 +121,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/c/chalk/_attachments/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -136,13 +136,13 @@
     },
     "babylon": {
       "version": "7.0.0-beta.19",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/b/babylon/_attachments/babylon-7.0.0-beta.19.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
       "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/b/balanced-match/_attachments/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bluebird": {
@@ -153,7 +153,7 @@
     },
     "bluetooth-hci-socket": {
       "version": "0.5.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/b/bluetooth-hci-socket/_attachments/bluetooth-hci-socket-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/bluetooth-hci-socket/-/bluetooth-hci-socket-0.5.1.tgz",
       "integrity": "sha1-774hUk/Bz10/rl1RNl1WHUq77Qs=",
       "optional": true,
       "requires": {
@@ -164,21 +164,30 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/d/debug/_attachments/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         }
       }
     },
     "bplist-parser": {
       "version": "0.0.6",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/b/bplist-parser/_attachments/bplist-parser-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.0.6.tgz",
       "integrity": "sha1-ONo0cYF9+dRKs4kuJ3B7u9daEbk=",
       "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/b/brace-expansion/_attachments/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -187,13 +196,13 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/b/builtin-modules/_attachments/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "cache-point": {
       "version": "0.4.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/cache-point/_attachments/cache-point-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
       "integrity": "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==",
       "dev": true,
       "requires": {
@@ -204,7 +213,7 @@
     },
     "catharsis": {
       "version": "0.8.9",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/catharsis/_attachments/catharsis-0.8.9.tgz",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
@@ -213,7 +222,7 @@
     },
     "chalk": {
       "version": "2.4.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/chalk/_attachments/chalk-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
@@ -224,7 +233,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/a/ansi-styles/_attachments/ansi-styles-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -233,7 +242,7 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/s/supports-color/_attachments/supports-color-5.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
@@ -244,17 +253,17 @@
     },
     "chownr": {
       "version": "1.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/chownr/_attachments/chownr-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/code-point-at/_attachments/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collect-all": {
       "version": "1.0.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/collect-all/_attachments/collect-all-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
       "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
       "dev": true,
       "requires": {
@@ -264,7 +273,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/color-convert/_attachments/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
@@ -273,13 +282,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/color-name/_attachments/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "command-line-args": {
       "version": "5.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/command-line-args/_attachments/command-line-args-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
       "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
       "dev": true,
       "requires": {
@@ -292,7 +301,7 @@
     },
     "command-line-tool": {
       "version": "0.8.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/command-line-tool/_attachments/command-line-tool-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
       "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
       "dev": true,
       "requires": {
@@ -305,7 +314,7 @@
     },
     "command-line-usage": {
       "version": "4.1.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/command-line-usage/_attachments/command-line-usage-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
       "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
       "dev": true,
       "requires": {
@@ -317,24 +326,24 @@
     },
     "commander": {
       "version": "2.17.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/commander/_attachments/commander-2.17.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
       "dev": true
     },
     "common-sequence": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/common-sequence/_attachments/common-sequence-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
       "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/concat-map/_attachments/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "config-master": {
       "version": "3.1.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/config-master/_attachments/config-master-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
       "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
       "dev": true,
       "requires": {
@@ -343,7 +352,7 @@
       "dependencies": {
         "walk-back": {
           "version": "2.0.1",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/w/walk-back/_attachments/walk-back-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
           "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
           "dev": true
         }
@@ -351,12 +360,12 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/console-control-strings/_attachments/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/c/core-util-is/_attachments/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
@@ -373,7 +382,7 @@
     },
     "debug": {
       "version": "3.2.6",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/d/debug/_attachments/debug-3.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
         "ms": "^2.1.1"
@@ -381,28 +390,28 @@
     },
     "deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/d/deep-extend/_attachments/deep-extend-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/d/delegates/_attachments/delegates-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/d/detect-libc/_attachments/detect-libc-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/d/diff/_attachments/diff-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dmd": {
       "version": "3.0.12",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/d/dmd/_attachments/dmd-3.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.12.tgz",
       "integrity": "sha512-79w644JdsB2TthYpVl2bDurX7i9Abaegg2E7X46Ajc135aASTMXxrHzJ9mOa5X5nbmnXwlBYiF68K+1baX+BzQ==",
       "dev": true,
       "requires": {
@@ -422,19 +431,19 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/e/escape-string-regexp/_attachments/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/e/esprima/_attachments/esprima-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/e/esutils/_attachments/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
@@ -450,7 +459,7 @@
     },
     "find-replace": {
       "version": "2.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/f/find-replace/_attachments/find-replace-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
       "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
       "dev": true,
       "requires": {
@@ -460,7 +469,7 @@
     },
     "fs-minipass": {
       "version": "1.2.5",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/f/fs-minipass/_attachments/fs-minipass-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
         "minipass": "^2.2.1"
@@ -468,18 +477,18 @@
     },
     "fs-then-native": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/f/fs-then-native/_attachments/fs-then-native-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
       "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/f/fs.realpath/_attachments/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/g/gauge/_attachments/gauge-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
         "aproba": "^1.0.3",
@@ -494,7 +503,7 @@
     },
     "glob": {
       "version": "7.1.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/g/glob/_attachments/glob-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -513,7 +522,7 @@
     },
     "handlebars": {
       "version": "4.0.12",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/h/handlebars/_attachments/handlebars-4.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
@@ -525,7 +534,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/h/has-ansi/_attachments/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -534,18 +543,18 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/h/has-flag/_attachments/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/h/has-unicode/_attachments/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/i/iconv-lite/_attachments/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -553,7 +562,7 @@
     },
     "ignore-walk": {
       "version": "3.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/i/ignore-walk/_attachments/ignore-walk-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
         "minimatch": "^3.0.4"
@@ -561,7 +570,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/i/inflight/_attachments/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -570,17 +579,17 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/i/inherits/_attachments/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/i/ini/_attachments/ini-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/i/is-fullwidth-code-point/_attachments/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
         "number-is-nan": "^1.0.0"
@@ -588,7 +597,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/i/isarray/_attachments/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
@@ -598,13 +607,13 @@
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/j/js-tokens/_attachments/js-tokens-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.12.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/j/js-yaml/_attachments/js-yaml-3.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
@@ -614,7 +623,7 @@
     },
     "js2xmlparser": {
       "version": "3.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/j/js2xmlparser/_attachments/js2xmlparser-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
       "dev": true,
       "requires": {
@@ -623,7 +632,7 @@
     },
     "jsdoc": {
       "version": "3.5.5",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/j/jsdoc/_attachments/jsdoc-3.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
       "dev": true,
       "requires": {
@@ -643,7 +652,7 @@
     },
     "jsdoc-api": {
       "version": "4.0.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/j/jsdoc-api/_attachments/jsdoc-api-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.3.tgz",
       "integrity": "sha512-dfYq9JgB+XahY0XfSEw93PmXmocjwYcvJ5aMuQUJ/OdDRGWamf2SSOk3W06Bsj8qdjp/UdefzqpP/mpwsvHuvA==",
       "dev": true,
       "requires": {
@@ -660,7 +669,7 @@
     },
     "jsdoc-parse": {
       "version": "3.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/j/jsdoc-parse/_attachments/jsdoc-parse-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
       "integrity": "sha512-btZLp4wYl90vcAfgk4hoGQbO17iBVrhh3LJRMKZNtZgniO3F8H2CjxXld0owBIB1XxN+j3bAcWZnZKMnSj3iMA==",
       "dev": true,
       "requires": {
@@ -674,7 +683,7 @@
     },
     "jsdoc-to-markdown": {
       "version": "4.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/j/jsdoc-to-markdown/_attachments/jsdoc-to-markdown-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz",
       "integrity": "sha512-LHJRoLoLyDdxNcColgkLoB/rFG5iRP+PNJjMILI0x+95IdEAtyjSt0wJ6ZlKxRpkhBYtQXTQQ119hMqPIUZzTQ==",
       "dev": true,
       "requires": {
@@ -689,7 +698,7 @@
     },
     "klaw": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/k/klaw/_attachments/klaw-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
       "dev": true,
       "requires": {
@@ -698,43 +707,43 @@
     },
     "lodash": {
       "version": "4.17.11",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/l/lodash/_attachments/lodash-4.17.11.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/l/lodash.camelcase/_attachments/lodash.camelcase-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.omit": {
       "version": "4.5.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/l/lodash.omit/_attachments/lodash.omit-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
     "lodash.padend": {
       "version": "4.6.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/l/lodash.padend/_attachments/lodash.padend-4.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
     "lodash.pick": {
       "version": "4.4.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/l/lodash.pick/_attachments/lodash.pick-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/m/marked/_attachments/marked-0.3.19.tgz",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/m/minimatch/_attachments/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -742,7 +751,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/m/minimist/_attachments/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -756,7 +765,7 @@
     },
     "minizlib": {
       "version": "1.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/m/minizlib/_attachments/minizlib-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
       "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
       "requires": {
         "minipass": "^2.2.1"
@@ -764,7 +773,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/m/mkdirp/_attachments/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -772,29 +781,29 @@
     },
     "mkdirp2": {
       "version": "1.0.4",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/m/mkdirp2/_attachments/mkdirp2-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
       "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
       "dev": true
     },
     "ms": {
       "version": "2.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/m/ms/_attachments/ms-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "nan": {
       "version": "2.11.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/nan/_attachments/nan-2.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
       "optional": true
     },
     "napi-thread-safe-callback": {
       "version": "0.0.6",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/napi-thread-safe-callback/_attachments/napi-thread-safe-callback-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/napi-thread-safe-callback/-/napi-thread-safe-callback-0.0.6.tgz",
       "integrity": "sha512-X7uHCOCdY4u0yamDxDrv3jF2NtYc8A1nvPzBQgvpoSX+WB3jAe2cVNsY448V1ucq7Whf9Wdy02HEUoLW5rJKWg=="
     },
     "needle": {
       "version": "2.2.4",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/needle/_attachments/needle-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
       "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
         "debug": "^2.1.2",
@@ -804,7 +813,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/d/debug/_attachments/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -812,7 +821,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/m/ms/_attachments/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
@@ -824,7 +833,7 @@
     },
     "noble": {
       "version": "1.9.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/noble/_attachments/noble-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/noble/-/noble-1.9.1.tgz",
       "integrity": "sha1-LM0x6tjsktv/bxmkLkILJYvNzdA=",
       "requires": {
         "bluetooth-hci-socket": "^0.5.1",
@@ -835,7 +844,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/d/debug/_attachments/debug-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "requires": {
             "ms": "0.7.1"
@@ -843,7 +852,7 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/m/ms/_attachments/ms-0.7.1.tgz",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
@@ -866,7 +875,7 @@
     },
     "node-pre-gyp": {
       "version": "0.10.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/node-pre-gyp/_attachments/node-pre-gyp-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
       "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
       "requires": {
         "detect-libc": "^1.0.2",
@@ -883,7 +892,7 @@
     },
     "nopt": {
       "version": "4.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/nopt/_attachments/nopt-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
         "abbrev": "1",
@@ -892,12 +901,12 @@
     },
     "npm-bundled": {
       "version": "1.0.5",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/npm-bundled/_attachments/npm-bundled-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
       "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
     },
     "npm-packlist": {
       "version": "1.1.12",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/npm-packlist/_attachments/npm-packlist-1.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
       "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
       "requires": {
         "ignore-walk": "^3.0.1",
@@ -906,7 +915,7 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/npmlog/_attachments/npmlog-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -917,29 +926,29 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/n/number-is-nan/_attachments/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/object-assign/_attachments/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-get": {
       "version": "2.1.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/object-get/_attachments/object-get-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
       "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
       "dev": true
     },
     "object-to-spawn-args": {
       "version": "1.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/object-to-spawn-args/_attachments/object-to-spawn-args-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
       "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/once/_attachments/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -947,7 +956,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/optimist/_attachments/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -957,17 +966,17 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/os-homedir/_attachments/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/os-tmpdir/_attachments/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/o/osenv/_attachments/osenv-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
         "os-homedir": "^1.0.0",
@@ -976,7 +985,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/p/path-is-absolute/_attachments/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -986,18 +995,18 @@
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/p/path-parse/_attachments/path-parse-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/p/process-nextick-args/_attachments/process-nextick-args-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "rc": {
       "version": "1.2.8",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/rc/_attachments/rc-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
         "deep-extend": "^0.6.0",
@@ -1008,14 +1017,14 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/m/minimist/_attachments/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/readable-stream/_attachments/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -1029,7 +1038,7 @@
     },
     "reduce-extract": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/reduce-extract/_attachments/reduce-extract-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
       "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
       "dev": true,
       "requires": {
@@ -1038,7 +1047,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/a/array-back/_attachments/array-back-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -1047,7 +1056,7 @@
         },
         "test-value": {
           "version": "1.1.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/t/test-value/_attachments/test-value-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
           "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
           "dev": true,
           "requires": {
@@ -1059,19 +1068,19 @@
     },
     "reduce-flatten": {
       "version": "1.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/reduce-flatten/_attachments/reduce-flatten-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
       "dev": true
     },
     "reduce-unique": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/reduce-unique/_attachments/reduce-unique-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
       "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
       "dev": true
     },
     "reduce-without": {
       "version": "1.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/reduce-without/_attachments/reduce-without-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
       "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
       "dev": true,
       "requires": {
@@ -1080,7 +1089,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/a/array-back/_attachments/array-back-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -1089,7 +1098,7 @@
         },
         "test-value": {
           "version": "2.1.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/t/test-value/_attachments/test-value-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
           "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
           "dev": true,
           "requires": {
@@ -1101,7 +1110,7 @@
     },
     "requizzle": {
       "version": "0.2.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/requizzle/_attachments/requizzle-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
@@ -1110,7 +1119,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/u/underscore/_attachments/underscore-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -1118,7 +1127,7 @@
     },
     "resolve": {
       "version": "1.8.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/resolve/_attachments/resolve-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
@@ -1127,7 +1136,7 @@
     },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/r/rimraf/_attachments/rimraf-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "^7.0.5"
@@ -1135,27 +1144,27 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/safe-buffer/_attachments/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/safer-buffer/_attachments/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/sax/_attachments/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.6.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/semver/_attachments/semver-5.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/set-blocking/_attachments/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
@@ -1173,12 +1182,12 @@
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/signal-exit/_attachments/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sort-array": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/sort-array/_attachments/sort-array-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
       "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
       "dev": true,
       "requires": {
@@ -1189,7 +1198,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/a/array-back/_attachments/array-back-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -1200,19 +1209,19 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/source-map/_attachments/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/sprintf-js/_attachments/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "stream-connect": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/stream-connect/_attachments/stream-connect-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
       "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
       "dev": true,
       "requires": {
@@ -1221,7 +1230,7 @@
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/a/array-back/_attachments/array-back-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
@@ -1232,13 +1241,13 @@
     },
     "stream-via": {
       "version": "1.0.4",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/stream-via/_attachments/stream-via-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/string-width/_attachments/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -1248,7 +1257,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/string_decoder/_attachments/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1256,7 +1265,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/strip-ansi/_attachments/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -1264,18 +1273,18 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/strip-json-comments/_attachments/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/s/supports-color/_attachments/supports-color-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "table-layout": {
       "version": "0.4.4",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/table-layout/_attachments/table-layout-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
       "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
       "dev": true,
       "requires": {
@@ -1288,7 +1297,7 @@
     },
     "taffydb": {
       "version": "2.6.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/taffydb/_attachments/taffydb-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
@@ -1308,13 +1317,13 @@
     },
     "temp-path": {
       "version": "1.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/temp-path/_attachments/temp-path-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
       "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
       "dev": true
     },
     "test-value": {
       "version": "3.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/test-value/_attachments/test-value-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
       "dev": true,
       "requires": {
@@ -1324,13 +1333,13 @@
     },
     "tslib": {
       "version": "1.9.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/tslib/_attachments/tslib-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "tslint": {
       "version": "5.11.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/tslint/_attachments/tslint-5.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
       "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
       "dev": true,
       "requires": {
@@ -1350,7 +1359,7 @@
     },
     "tsutils": {
       "version": "2.29.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/tsutils/_attachments/tsutils-2.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
@@ -1359,19 +1368,19 @@
     },
     "typescript": {
       "version": "2.9.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/typescript/_attachments/typescript-2.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
     },
     "typical": {
       "version": "2.6.1",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/t/typical/_attachments/typical-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/u/uglify-js/_attachments/uglify-js-3.4.9.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
       "optional": true,
@@ -1382,13 +1391,13 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/u/underscore/_attachments/underscore-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
     "underscore-contrib": {
       "version": "0.3.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/u/underscore-contrib/_attachments/underscore-contrib-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
       "dev": true,
       "requires": {
@@ -1397,7 +1406,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "https://npm-registry.rancher.sie.sony.com/u/underscore/_attachments/underscore-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -1405,7 +1414,7 @@
     },
     "usb": {
       "version": "1.3.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/u/usb/_attachments/usb-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-1.3.3.tgz",
       "integrity": "sha512-WRBxI54yEs2QPj28G6kITI3Wu7VxrtHbqiDvDRUDKdg97lcK1pTP8y9LoDWF22OiCCrEvrdeq0lNcr84QOzjXQ==",
       "optional": true,
       "requires": {
@@ -1415,12 +1424,12 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/u/util-deprecate/_attachments/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "walk-back": {
       "version": "3.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/w/walk-back/_attachments/walk-back-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
       "integrity": "sha1-I1h4ejXakQMtrV6S+AsSNw2HlcU=",
       "dev": true
     },
@@ -1434,7 +1443,7 @@
     },
     "wide-align": {
       "version": "1.1.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/w/wide-align/_attachments/wide-align-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
@@ -1442,13 +1451,13 @@
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/w/wordwrap/_attachments/wordwrap-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wordwrapjs": {
       "version": "3.0.0",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/w/wordwrapjs/_attachments/wordwrapjs-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "dev": true,
       "requires": {
@@ -1458,12 +1467,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/w/wrappy/_attachments/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xmlcreate": {
       "version": "1.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/x/xmlcreate/_attachments/xmlcreate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
@@ -1478,7 +1487,7 @@
     },
     "yallist": {
       "version": "3.0.2",
-      "resolved": "https://npm-registry.rancher.sie.sony.com/y/yallist/_attachments/yallist-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
       "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-poweredup",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A Node.js module to interface with LEGO Powered UP components.",
   "homepage": "https://github.com/nathankellenicki/node-poweredup/",
-  "main": "dist/poweredup.js",
-  "types": "dist/poweredup.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tslint -c tslint.json \"*.ts\" && tsc",
     "docs": "jsdoc2md dist/poweredup.js dist/lpf2hub.js dist/wedo2smarthub.js dist/boostmovehub.js dist/puphub.js dist/pupremote.js dist/duplotrainbase.js dist/hub.js dist/consts.js > DOCS.md",

--- a/poweredup.ts
+++ b/poweredup.ts
@@ -16,7 +16,6 @@ import { EventEmitter } from "events";
 import Debug = require("debug");
 const debug = Debug("PoweredUP");
 import noble = require("noble-mac");
-import { start } from "repl";
 
 let ready = false;
 let wantScan = false;
@@ -153,6 +152,3 @@ export class PoweredUP extends EventEmitter {
 
 
 }
-
-export default PoweredUP;
-export { Hub, WeDo2SmartHub, BoostMoveHub, PUPHub, PUPRemote, Consts };


### PR DESCRIPTION
I moved the library exports into index.ts from poweredup.ts since TypeScript looks for an index.ts or index.d.ts as the root of the module when resolving modules imported through NPM. Following the existing instructions to 

`npm install node-poweredup --save`

and then referencing

`const PoweredUP = require("node-poweredup");`

in TypeScript results in a "Unable to find module 'node-poweredup'" error when running `tsc` despite the module being present in node_modules. By moving the exports to index.ts, I corrected this error and verified that the library works correctly against my Boost Movehub when importing as an npm package.