### PR TITLE
remove colorAndDistance event from DuploTrainBase docs

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1492,7 +1492,6 @@ A combined color and distance event, emits when the sensor is activated.
     * [.getHubType()](#Hub+getHubType) ⇒ [<code>HubType</code>](#HubType)
     * [.getPortDeviceType(port)](#Hub+getPortDeviceType) ⇒ [<code>DeviceType</code>](#DeviceType)
     * ["color" (port, color)](#LPF2Hub+event_color)
-    * ["colorAndDistance" (port, color, distance)](#LPF2Hub+event_colorAndDistance)
     * ["speed" (port, speed)](#LPF2Hub+event_speed)
 
 <a name="new_DuploTrainBase_new"></a>
@@ -1754,19 +1753,6 @@ Emits when a color sensor is activated.
 | --- | --- |
 | port | <code>string</code> | 
 | color | [<code>Color</code>](#Color) | 
-
-<a name="LPF2Hub+event_colorAndDistance"></a>
-
-### "colorAndDistance" (port, color, distance)
-A combined color and distance event, emits when the sensor is activated.
-
-**Kind**: event emitted by [<code>DuploTrainBase</code>](#DuploTrainBase)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| port | <code>string</code> |  |
-| color | [<code>Color</code>](#Color) |  |
-| distance | <code>number</code> | Distance, in millimeters. |
 
 <a name="LPF2Hub+event_speed"></a>
 

--- a/README.md
+++ b/README.md
@@ -1585,7 +1585,6 @@ A combined color and distance event, emits when the sensor is activated.
     * [.getHubType()](#Hub+getHubType) ⇒ [<code>HubType</code>](#HubType)
     * [.getPortDeviceType(port)](#Hub+getPortDeviceType) ⇒ [<code>DeviceType</code>](#DeviceType)
     * ["color" (port, color)](#LPF2Hub+event_color)
-    * ["colorAndDistance" (port, color, distance)](#LPF2Hub+event_colorAndDistance)
     * ["speed" (port, speed)](#LPF2Hub+event_speed)
 
 <a name="new_DuploTrainBase_new"></a>
@@ -1847,19 +1846,6 @@ Emits when a color sensor is activated.
 | --- | --- |
 | port | <code>string</code> | 
 | color | [<code>Color</code>](#Color) | 
-
-<a name="LPF2Hub+event_colorAndDistance"></a>
-
-### "colorAndDistance" (port, color, distance)
-A combined color and distance event, emits when the sensor is activated.
-
-**Kind**: event emitted by [<code>DuploTrainBase</code>](#DuploTrainBase)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| port | <code>string</code> |  |
-| color | [<code>Color</code>](#Color) |  |
-| distance | <code>number</code> | Distance, in millimeters. |
 
 <a name="LPF2Hub+event_speed"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-poweredup",
-  "version": "1.4.8",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/duplotrainbase.ts
+++ b/src/duplotrainbase.ts
@@ -26,6 +26,11 @@ export class DuploTrainBase extends LPF2Hub {
      */
 
     /**
+     * @event DuploTrainBase#colorAndDistance
+     * @ignore
+     */
+
+    /**
      * @event DuploTrainBase#tilt
      * @ignore
      */


### PR DESCRIPTION
I don't think the Duplo train has a distance sensor.