### PR TITLE
Fixed broken device type query

### DIFF
--- a/examples/train_controller.js
+++ b/examples/train_controller.js
@@ -117,7 +117,7 @@ poweredUP.on("discover", async (hub) => {
                 hub.setLEDColor(train.color);
                 console.log(`Connected to ${train.name} (${hub.name})`);
                 hub.on("attach", (port, type) => {
-                    if (type === PoweredUP.Consts.Devices.LED_LIGHTS && trainHub.lights && trainHub.lights.indexOf(port) >= 0) {
+                    if (type === PoweredUP.Consts.DeviceType.LED_LIGHTS && trainHub.lights && trainHub.lights.indexOf(port) >= 0) {
                         hub.setLightBrightness(port, 100);
                     }
                 });


### PR DESCRIPTION
Replaced "Devices.LED_LIGHTS" with "DeviceType.LED_LIGHTS" 
Because "Devices.LED_LIGHTS" is undefined (maybe deprecated)