### PR TITLE
allow RGB led control for the duplo train hub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-poweredup",
-  "version": "2.5.3",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-poweredup",
-  "version": "3.5.1",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/duplotrainbase.ts
+++ b/src/duplotrainbase.ts
@@ -26,6 +26,9 @@ export class DuploTrainBase extends LPF2Hub {
     }
 
 
+    protected _ledPort = 0x11;
+
+
     constructor (device: IBLEDevice, autoSubscribe: boolean = true) {
         super(device, autoSubscribe);
         this.type = Consts.HubType.DUPLO_TRAIN_HUB;
@@ -46,25 +49,6 @@ export class DuploTrainBase extends LPF2Hub {
             return resolve();
         });
     }
-
-
-    /**
-     * Set the color of the LED on the train via a color value.
-     * @method DuploTrainBase#setLEDColor
-     * @param {Color} color
-     * @returns {Promise} Resolved upon successful issuance of command.
-     */
-    public setLEDColor (color: number | boolean) {
-        return new Promise((resolve, reject) => {
-            if (typeof color === "boolean") {
-                color = 0;
-            }
-            const data = Buffer.from([0x81, 0x11, 0x11, 0x51, 0x00, color]);
-            this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
-            return resolve();
-        });
-    }
-
 
     /**
      * Set the motor speed on a given port.

--- a/src/lpf2hub.ts
+++ b/src/lpf2hub.ts
@@ -16,6 +16,8 @@ const modeInfoDebug = Debug("lpf2hubmodeinfo");
  */
 export class LPF2Hub extends Hub {
 
+    protected _ledPort: number = 0x32;
+
     private _lastTiltX: number = 0;
     private _lastTiltY: number = 0;
     private _lastTiltZ: number = 0;
@@ -111,9 +113,9 @@ export class LPF2Hub extends Hub {
      */
     public setLEDRGB (red: number, green: number, blue: number) {
         return new Promise((resolve, reject) => {
-            let data = Buffer.from([0x41, 0x32, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00]);
+            let data = Buffer.from([0x41, this._ledPort, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00]);
             this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
-            data = Buffer.from([0x81, 0x32, 0x11, 0x51, 0x01, red, green, blue]);
+            data = Buffer.from([0x81, this._ledPort, 0x11, 0x51, 0x01, red, green, blue]);
             this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
             return resolve();
         });

--- a/src/lpf2hub.ts
+++ b/src/lpf2hub.ts
@@ -91,12 +91,12 @@ export class LPF2Hub extends Hub {
      */
     public setLEDColor (color: number | boolean) {
         return new Promise((resolve, reject) => {
-            let data = Buffer.from([0x41, 0x32, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+            let data = Buffer.from([0x41, this._ledPort, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
             this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
             if (typeof color === "boolean") {
                 color = 0;
             }
-            data = Buffer.from([0x81, 0x32, 0x11, 0x51, 0x00, color]);
+            data = Buffer.from([0x81, this._ledPort, 0x11, 0x51, 0x00, color]);
             this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
             return resolve();
         });

--- a/src/pupremote.ts
+++ b/src/pupremote.ts
@@ -26,6 +26,9 @@ export class PUPRemote extends LPF2Hub {
     }
 
 
+    protected _ledPort = 0x34;
+
+
     constructor (device: IBLEDevice, autoSubscribe: boolean = true) {
         super(device, autoSubscribe);
         this.type = Consts.HubType.POWERED_UP_REMOTE;
@@ -42,45 +45,6 @@ export class PUPRemote extends LPF2Hub {
             debug("Connecting to Powered UP Remote");
             await super.connect();
             debug("Connect completed");
-            return resolve();
-        });
-    }
-
-
-    /**
-     * Set the color of the LED on the Remote via a color value.
-     * @method PUPRemote#setLEDColor
-     * @param {Color} color
-     * @returns {Promise} Resolved upon successful issuance of command.
-     */
-    public setLEDColor (color: number | boolean) {
-        return new Promise((resolve, reject) => {
-            let data = Buffer.from([0x41, 0x34, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
-            this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
-            if (typeof color === "boolean") {
-                color = 0;
-            }
-            data = Buffer.from([0x81, 0x34, 0x11, 0x51, 0x00, color]);
-            this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
-            return resolve();
-        });
-    }
-
-
-    /**
-     * Set the color of the LED on the Hub via RGB values.
-     * @method PUPRemote#setLEDRGB
-     * @param {number} red
-     * @param {number} green
-     * @param {number} blue
-     * @returns {Promise} Resolved upon successful issuance of command.
-     */
-    public setLEDRGB (red: number, green: number, blue: number) {
-        return new Promise((resolve, reject) => {
-            let data = Buffer.from([0x41, 0x34, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00]);
-            this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
-            data = Buffer.from([0x81, 0x34, 0x11, 0x51, 0x01, red, green, blue]);
-            this._writeMessage(Consts.BLECharacteristic.LPF2_ALL, data);
             return resolve();
         });
     }


### PR DESCRIPTION
Duplo train LED has both indexed color and rgb modes just like other hubs, so it can be controlled with the same code.