### PR TITLE
Fix and simplify tilt sensor reading

### DIFF
--- a/src/lpf2hub.ts
+++ b/src/lpf2hub.ts
@@ -496,8 +496,8 @@ export class LPF2Hub extends Hub {
                     break;
                 }
                 case Consts.DeviceType.WEDO2_TILT: {
-                    const tiltX = data[4] > 160 ? data[4] - 255 : data[4] - (data[4] * 2);
-                    const tiltY = data[5] > 160 ? 255 - data[5] : data[5] - (data[5] * 2);
+                    const tiltX = data.readInt8(4);
+                    const tiltY = data.readInt8(5);
                     this._lastTiltX = tiltX;
                     this._lastTiltY = tiltY;
                     /**
@@ -538,8 +538,8 @@ export class LPF2Hub extends Hub {
                     break;
                 }
                 case Consts.DeviceType.BOOST_TILT: {
-                    const tiltX = data[4] > 160 ? data[4] - 255 : data[4];
-                    const tiltY = data[5] > 160 ? 255 - data[5] : data[5] - (data[5] * 2);
+                    const tiltX = data.readInt8(4);
+                    const tiltY = data.readInt8(5);
                     this._lastTiltX = tiltX;
                     this._lastTiltY = tiltY;
                     this.emit("tilt", port.id, this._lastTiltX, this._lastTiltY, this._lastTiltZ);

--- a/src/wedo2smarthub.ts
+++ b/src/wedo2smarthub.ts
@@ -419,14 +419,8 @@ export class WeDo2SmartHub extends Hub {
                     break;
                 }
                 case Consts.DeviceType.WEDO2_TILT: {
-                    this._lastTiltX = data[2];
-                    if (this._lastTiltX > 100) {
-                        this._lastTiltX = -(255 - this._lastTiltX);
-                    }
-                    this._lastTiltY = data[3];
-                    if (this._lastTiltY > 100) {
-                        this._lastTiltY = -(255 - this._lastTiltY);
-                    }
+                    this._lastTiltX = data.readInt8(2);
+                    this._lastTiltY = data.readInt8(3);
                     /**
                      * Emits when a tilt sensor is activated.
                      * @event WeDo2SmartHub#tilt


### PR DESCRIPTION
WeDo tilt sensor in Mode 0 and Boost Move tilt sensor in mode 4 both return signed 8 bit integers. So they can be directly read as such.
The existing code was causing 2 issues:
- WeDo tilt X axis value was always positive (in both directions)
- Boost move mode 4 range is -128 to 127, so some negative values were reported as positive in range 128 - 160
Also the sign of the raw read was sometimes reversed, not sure if this was intentional. I undone it, but could be reverted to maintain backwards compatibility. 
