### PR TITLE
allow switching to mode 0 in Hub.subscribe()

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -149,7 +149,7 @@ export class Hub extends EventEmitter {
     public subscribe (port: string, mode?: number) {
         return new Promise((resolve, reject) => {
             let newMode = this._getModeForDeviceType(this._portLookup(port).type);
-            if (mode) {
+            if (mode !== undefined) {
                 newMode = mode;
             }
             this._activatePortDevice(this._portLookup(port).value, this._portLookup(port).type, newMode, 0x00, () => {


### PR DESCRIPTION
Trying to switch to mode 0 resulted in switching to the default mode (for example mode 4 for boost tilt sensor).