### PR TITLE
LPF2 firmware versions should be decoded with BCD

### DIFF
--- a/src/boostmovehub.ts
+++ b/src/boostmovehub.ts
@@ -304,7 +304,7 @@ export class BoostMoveHub extends LPF2Hub {
 
 
     protected _checkFirmware (version: string) {
-        if (compareVersion("2.0.00.0023", version) === 1) {
+        if (compareVersion("2.0.00.0017", version) === 1) {
             throw new Error(`Your Boost Move Hub's (${this.name}) firmware is out of date and unsupported by this library. Please update it via the official Powered Up app.`);
         }
     }

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 
-import { IBLEDevice, IFirmwareInfo } from "./interfaces";
+import { IBLEDevice } from "./interfaces";
 import { Port } from "./port";
 
 import * as Consts from "./consts";
@@ -24,7 +24,7 @@ export class Hub extends EventEmitter {
     protected _virtualPorts: {[port: string]: Port} = {};
 
     protected _name: string = "";
-    protected _firmwareInfo: IFirmwareInfo = { major: 0, minor: 0, bugFix: 0, build: 0 };
+    protected _firmwareVersion: string = "0.0.00.0000";
     protected _batteryLevel: number = 100;
     protected _voltage: number = 0;
     protected _current: number = 0;
@@ -59,7 +59,7 @@ export class Hub extends EventEmitter {
      * @property {string} firmwareVersion Firmware version of the hub
      */
     public get firmwareVersion () {
-        return `${this._firmwareInfo.major}.${this._firmwareInfo.minor}.${this._lpad(this._firmwareInfo.bugFix.toString(), 2)}.${this._lpad(this._firmwareInfo.build.toString(), 4)}`;
+        return this._firmwareVersion;
     }
 
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,13 +1,5 @@
 import { EventEmitter } from "events";
 
-export interface IFirmwareInfo {
-    major: number;
-    minor: number;
-    bugFix: number;
-    build: number;
-}
-
-
 export interface IBLEDevice extends EventEmitter {
     uuid: string;
     name: string;

--- a/src/lpf2hub.ts
+++ b/src/lpf2hub.ts
@@ -15,6 +15,10 @@ const modeInfoDebug = Debug("lpf2hubmodeinfo");
  * @extends Hub
  */
 export class LPF2Hub extends Hub {
+    private static decodeVersion(v: number) {
+        const t = v.toString(16).padStart(8, "0");
+        return [t[0], t[1], t.substring(2, 4), t.substring(4)].join(".");
+    }
 
     private _lastTiltX: number = 0;
     private _lastTiltY: number = 0;
@@ -241,12 +245,8 @@ export class LPF2Hub extends Hub {
 
         // Firmware version
         } else if (data[3] === 0x03) {
-            const build = data.readUInt16LE(5);
-            const bugFix = data.readUInt8(7);
-            const major = data.readUInt8(8) >>> 4;
-            const minor = data.readUInt8(8) & 0xf;
-            this._firmwareInfo = { major, minor, bugFix, build };
-            this._checkFirmware(this.firmwareVersion);
+            this._firmwareVersion = LPF2Hub.decodeVersion(data.readInt32LE(5));
+            this._checkFirmware(this._firmwareVersion);
 
         // Battery level reports
         } else if (data[3] === 0x06) {

--- a/src/wedo2smarthub.ts
+++ b/src/wedo2smarthub.ts
@@ -336,8 +336,7 @@ export class WeDo2SmartHub extends Hub {
 
     private _parseFirmwareRevisionString (data: Buffer) {
         debug("Received Message (WEDO2_FIRMWARE_REVISION)", data);
-        const parts = data.toString().split(".");
-        this._firmwareInfo = { major: parseInt(parts[0], 10), minor: parseInt(parts[1], 10), bugFix: parseInt(parts[2], 10), build: parseInt(parts[3], 10) };
+        this._firmwareVersion = data.toString();
     }
 
 


### PR DESCRIPTION
As per the official protocol specification all 4 byte version numbers are using BCD number encoding: https://lego.github.io/lego-ble-wireless-protocol-docs/index.html#version-number-encoding