### PR TITLE
Remove sources from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,17 +1,5 @@
-boostmovehub.ts
-consts.ts
-duplotrainbase.ts
-hub.ts
-index.ts
-lpf2hub.ts
-port.ts
-poweredup.ts
-puphub.ts
-pupremote.ts
 package-lock.json
 tsconfig.json
 tslint.json
-utils.ts
-wedo2smarthub.ts
 .vscode/
 examples/


### PR DESCRIPTION
It allows to import the sources to be bundled with main app if needed

E.g:
```js
import { PoweredUp } from 'node-poweredup/src/poweredup-browser';

const poweredUP = new PoweredUP();
```
Then the lib is not exposed to the `window` scope and bundled with the app source.