### PR TITLE
Add PoweredUP#getConnectedHubByPrimaryMACAddress

### DIFF
--- a/src/poweredup-browser.ts
+++ b/src/poweredup-browser.ts
@@ -97,6 +97,17 @@ export class PoweredUP extends EventEmitter {
 
 
     /**
+     * Retrieve a Powered UP Hub by primary MAC address.
+     * @method PoweredUP#getConnectedHubByPrimaryMACAddress
+     * @param {string} address
+     * @returns {Hub}
+     */
+    public getConnectedHubByPrimaryMACAddress (address: string) {
+        return Object.keys(this._connectedHubs).map((uuid) => this._connectedHubs[uuid]).filter((hub) => hub.primaryMACAddress === address)[0];
+    }
+
+
+    /**
      * Retrieve a list of Powered UP Hub by name.
      * @method PoweredUP#getConnectedHubsByName
      * @param {string} name

--- a/src/poweredup-node.ts
+++ b/src/poweredup-node.ts
@@ -115,6 +115,17 @@ export class PoweredUP extends EventEmitter {
 
 
     /**
+     * Retrieve a Powered UP Hub by primary MAC address.
+     * @method PoweredUP#getConnectedHubByPrimaryMACAddress
+     * @param {string} address
+     * @returns {Hub}
+     */
+    public getConnectedHubByPrimaryMACAddress (address: string) {
+        return Object.keys(this._connectedHubs).map((uuid) => this._connectedHubs[uuid]).filter((hub) => hub.primaryMACAddress === address)[0];
+    }
+
+
+    /**
      * Retrieve a list of Powered UP Hub by name.
      * @method PoweredUP#getConnectedHubsByName
      * @param {string} name


### PR DESCRIPTION
Predictable pull request following #47 

Allow to retrieve hub by its primary MAC address but:
- it assumes those addresses are really unique (they should be)
- if not it returns the first hub found matching provided address