### PR TITLE
Attempt to read differents device modes

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -186,3 +186,31 @@ export enum BLECharacteristic {
     WEDO2_NAME_ID = "00001524-1212-efde-1523-785feabcd123", // "1524"
     LPF2_ALL = "00001624-1212-efde-1623-785feabcd123"
 }
+
+export enum ColorAndDistanceInputModes {
+    COLOR = 0,
+    PROX = 1,
+    COUNT = 2,
+    REFLT = 3,
+    AMBI = 4,
+    RGB_I = 6,
+    SPEC_1 = 8
+}
+
+export enum BoostTiltModes {
+    ANGLE = 0,
+    TILT = 1,
+    ORINT = 2,
+    IMPCT = 3,
+    ACCEL = 4,
+    OR_CF = 5,
+    IM_CF = 6,
+    CALIB = 7
+}
+
+export enum MotorModes {
+    POWER = 0,
+    SPEED = 1,
+    POS = 2,
+    APOS = 3
+}

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -157,11 +157,15 @@ export class Hub extends EventEmitter {
      */
     public subscribe (port: string, mode?: number) {
         return new Promise((resolve, reject) => {
-            let newMode = this._getModeForDeviceType(this._portLookup(port).type);
+            const { type, value } = this._portLookup(port);
+
+            let newMode = this._getModeForDeviceType(type);
             if (mode !== undefined) {
                 newMode = mode;
             }
-            this._activatePortDevice(this._portLookup(port).value, this._portLookup(port).type, newMode, 0x00, () => {
+
+            this._ports[port].mode = newMode;
+            this._activatePortDevice(value, type, newMode, 0x00, () => {
                 return resolve();
             });
         });
@@ -175,8 +179,8 @@ export class Hub extends EventEmitter {
      */
     public unsubscribe (port: string) {
         return new Promise((resolve, reject) => {
-            const mode = this._getModeForDeviceType(this._portLookup(port).type);
-            this._deactivatePortDevice(this._portLookup(port).value, this._portLookup(port).type, mode, 0x00, () => {
+            const { type, value, mode } = this._portLookup(port);
+            this._deactivatePortDevice(value, type, mode || this._getModeForDeviceType(type), 0x00, () => {
                 return resolve();
             });
         });

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -283,6 +283,7 @@ export class Hub extends EventEmitter {
             }
         } else {
             port.type = Consts.DeviceType.UNKNOWN;
+            port.mode = null;
             debug(`Port ${port.id} disconnected`);
             /**
              * Emits when an attached motor or sensor is detached from the Hub.

--- a/src/lpf2hub.ts
+++ b/src/lpf2hub.ts
@@ -636,7 +636,7 @@ export class LPF2Hub extends Hub {
              * @param {number} g
              * @param {number} b
              */
-            this.emit("rgb", port.id, data[4], data[6], data[8]);
+            this.emit("rgb", port.id, data.readInt16LE(4), data.readInt16LE(6), data.readInt16LE(8));
         }
     }
 

--- a/src/port.ts
+++ b/src/port.ts
@@ -7,6 +7,7 @@ export class Port {
     public id: string;
     public value: number;
     public type: Consts.DeviceType;
+    public mode: number | null;
     public connected: boolean = false;
     public busy: boolean = false;
     public finished: (() => void) | null = null;
@@ -17,6 +18,7 @@ export class Port {
         this.id = id;
         this.value = value;
         this.type = Consts.DeviceType.UNKNOWN;
+        this.mode = null;
     }
 
     public cancelEventTimer () {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,3 +7,6 @@ export function toHex (value: number, length: number = 2) {
 export function toBin (value: number, length: number = 8) {
     return value.toString(2).padStart(length, "0");
 }
+export function toDistance(value: number, partial: number = 1) {
+    return Math.floor((value + 1 / Math.max(partial, 1)) * 25.4) - 20;
+}


### PR DESCRIPTION
**This is not ready to be merged**, working on #55 took me further than I expected and I ended trying to read every input mode from every device I have.

Now I need help/advice/review to check what I did wrong and test devices I don't have (WeDo2 hub and accessories, Duplo train base)

To handle different data from different mode I added several events:

- BOOST_DISTANCE
  - count
  - reflectivity
  - luminosity
  - rgb
- Motors
  - power
  - speed
  - absolutePosition
- BOOST_TILT
  - angle
  - orientation
  - impact
  - accel

---

Using the debug output I summed up mode numbers and names for each hub.
The bad news is: the same device on different hubs does not expose exactly the same modes.

### Color and distance

| HUB              | 0x00  | 0x01  | 0x02  | 0x03  | 0x04  | 0x05  | 0x06  | 0x07  | 0x08   | 0x09  | 0x0a  |
| ---------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ------ | ----- | ----- |
| WEDO2_SMART_HUB  | ?     | ?     | ?     | ?     | ?     | ?     | ?     | ?     | ?      | ?     | ?     |
| BOOST_MOVE_HUB   | COLOR | PROX  | COUNT | REFLT | AMBI  | COL_O | RGB_I | IR_Tx | SPEC_1 | DEBUG | CALIB |
| POWERED_UP_HUB   | COLOR | PROX  | COUNT | REFLT | AMBI  | COL_O | RGB_I | IR_Tx | SPEC_1 | DEBUG | CALIB |
| CONTROL_PLUS_HUB | COLOR | PROX  | COUNT | REFLT | AMBI  | COL_O | RGB_I | IR_Tx | SPEC_1 | DEBUG | CALIB |


### Motors

**BASIC_MOTOR**

| HUB              | 0x00        |
| ---------------- | ----------- |
| WEDO2_SMART_HUB  | ?           |
| BOOST_MOVE_HUB   | LPF2-MMOTOR |
| POWERED_UP_HUB   | LPF2-MMOTOR |
| CONTROL_PLUS_HUB | LPF2-MMOTOR |


**BOOST_TACHO_MOTOR**

| HUB              | 0x00  | 0x01  | 0x02| 0x03 |
| ---------------- | ----- | ----- | --- | ---- |
| WEDO2_SMART_HUB  | ?     | ?     | ?   | ?    |
| BOOST_MOVE_HUB   | POWER | SPEED | POS | TEST |
| POWERED_UP_HUB   | POWER | SPEED | POS |      |
| CONTROL_PLUS_HUB | POWER | SPEED | POS |      |


**BOOST_MOVE_HUB_MOTOR**

| HUB              | 0x00  | 0x01  | 0x02 |
| ---------------- | ----- | ----- | ---- |
| BOOST_MOVE_HUB   | POWER | SPEED | POS  |


**CONTROL_PLUS_LARGE_MOTOR** / **CONTROL_PLUS_XLARGE_MOTOR**

| HUB              | 0x00  | 0x01  | 0x02| 0x03 | 0x04  | 0x05  |
| ---------------- | ----- | ----- | --- | ---- | ----- | ----- |
| WEDO2_SMART_HUB  | ?     | ?     | ?   | ?    | ?     | ?     |
| BOOST_MOVE_HUB   | POWER | SPEED | POS | APOS | CALIB | STATS |
| POWERED_UP_HUB   | POWER | SPEED | POS | APOS | LOAD  | CALIB |
| CONTROL_PLUS_HUB | POWER | SPEED | POS | APOS | LOAD  | CALIB |


### Tilt/accel sensors

**Internal**

| HUB              | Port | 0x00  | 0x01  | 0x02  | 0x03  | 0x04  | 0x05  | 0x06  | 0x07  |
| ---------------- | ---- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| BOOST_MOVE_HUB   | 0x3a | ANGLE | TILT  | ORINT | IMPCT | ACCEL | OR_CF | IM_CF | CALIB |
| CONTROL_PLUS_HUB | 0x62 | ROT   |       |       |       |       |       |       |       |
| CONTROL_PLUS_HUB | 0x63 | POS   | IMP   | CFG   |       |       |       |       |       |

**WeDo tilt sensor**

???
