### PR TITLE
Experiment: read sensor data with mode informations

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -186,3 +186,18 @@ export enum BLECharacteristic {
     WEDO2_NAME_ID = "00001524-1212-efde-1523-785feabcd123", // "1524"
     LPF2_ALL = "00001624-1212-efde-1623-785feabcd123"
 }
+
+
+export enum ValueType {
+    Int8,
+    Int16,
+    Int32,
+    Float
+}
+
+export const VALUE_SIZE = {
+    [ValueType.Int8]: 1,
+    [ValueType.Int16]: 2,
+    [ValueType.Int32]: 4,
+    [ValueType.Float]: 4
+};

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -297,6 +297,7 @@ export class Hub extends EventEmitter {
             }
         } else {
             port.type = Consts.DeviceType.UNKNOWN;
+            port.modes = [];
             debug(`Port ${port.id} disconnected`);
             /**
              * Emits when an attached motor or sensor is detached from the Hub.

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -168,21 +168,20 @@ export class Hub extends EventEmitter {
         });
     }
 
-    public subscribeByModeName (port: string, mode: string = "") {
-        const { value, type, modes } = this._portLookup(port);
+    public subscribeByModeName (port: string, mode?: string) {
+        const { modes } = this._portLookup(port);
+        const modeCode = modes.reduce(
+            (foundMode: number | null, definition, index) => {
+                return definition.name === mode ? index : foundMode;
+            },
+            null
+        );
 
-        return new Promise((resolve, reject) => {
-            this._activatePortDevice(
-                value,
-                type,
-                modes.reduce(
-                    (newMode, definition, index) => definition.name === mode ? index : newMode,
-                    this._getModeForDeviceType(type)
-                ),
-                0x00,
-                () => resolve()
-            );
-        });
+        if (!modeCode) {
+            throw new Error('Unknown device mode');
+        } else {
+            return this.subscribe(port, modeCode);
+        }
     }
 
     /**

--- a/src/lpf2hub.ts
+++ b/src/lpf2hub.ts
@@ -380,6 +380,7 @@ export class LPF2Hub extends Hub {
                 modeInfoDebug(`Port ${portHex}, mode ${mode}, name ${name}`);
                 break;
             case 0x01: // RAW Range
+                port.modes[mode].rawMin = data.readFloatLE(6);
                 modeInfoDebug(`Port ${portHex}, mode ${mode}, RAW min ${data.readFloatLE(6)}, max ${data.readFloatLE(10)}`);
                 break;
             case 0x02: // PCT Range
@@ -456,17 +457,18 @@ export class LPF2Hub extends Hub {
         if (port && port.connected && port.mode && port.modes[port.mode]) {
             const mode = port.modes[port.mode];
             const values = [];
+            const signed = mode.rawMin < 0;
 
             for (let index = 4; index < data.length; index += Consts.VALUE_SIZE[mode.valueType]) {
                 switch (mode.valueType) {
                     case Consts.ValueType.Int8:
-                        values.push(data.readInt8(index));
+                        values.push(signed ? data.readInt8(index) : data.readUInt8(index));
                         break;
                     case Consts.ValueType.Int16:
-                        values.push(data.readInt16LE(index));
+                        values.push(signed ? data.readInt16LE(index) : data.readUInt16LE(index));
                         break;
                     case Consts.ValueType.Int32:
-                        values.push(data.readInt32LE(index));
+                        values.push(signed ? data.readInt32LE(index) : data.readUInt32LE(index));
                         break;
                     case Consts.ValueType.Float:
                         values.push(data.readFloatLE(index));

--- a/src/lpf2hub.ts
+++ b/src/lpf2hub.ts
@@ -454,7 +454,7 @@ export class LPF2Hub extends Hub {
             return;
         }
 
-        if (port && port.connected && port.mode && port.modes[port.mode]) {
+        if (port.connected && port.mode !== null && port.modes[port.mode]) {
             const mode = port.modes[port.mode];
             const values = [];
             const signed = mode.rawMin < 0;

--- a/src/port.ts
+++ b/src/port.ts
@@ -1,15 +1,20 @@
 import * as Consts from "./consts";
 
+export interface IPortMode {
+    name: string;
+    unit: string;
+    valueType: Consts.ValueType;
+}
 
 export class Port {
-
-
     public id: string;
     public value: number;
     public type: Consts.DeviceType;
     public connected: boolean = false;
     public busy: boolean = false;
     public finished: (() => void) | null = null;
+    public mode: number | null = null;
+    public modes: IPortMode[] = [];
 
     private _eventTimer: NodeJS.Timer | null = null;
 

--- a/src/port.ts
+++ b/src/port.ts
@@ -3,6 +3,7 @@ import * as Consts from "./consts";
 export interface IPortMode {
     name: string;
     unit: string;
+    rawMin: number;
     valueType: Consts.ValueType;
 }
 


### PR DESCRIPTION
**Once again this is not meant to be merged as it breaks everything.**

Since the LWP3 exposes mode information with name and data format for parsing, I tried to implement some kind of "auto parsing":
- it parse data using mode information
- emit a `sensor` event with mode name and raw parsed data array (which allow to listen to events not handled by the lib)
- emit *almost* the same events the library already have

BUT: It does not work very well as I don't know how to get the mode information before the `attach` event is emited. As is, it just ignore sensor events until the mode information got collected...


If anyone see value in this and wants to help, I would be very happy to know if there is a way to make it reliable.

