### PR TITLE
Fix message length comparison

### DIFF
--- a/src/hubs/lpf2hub.ts
+++ b/src/hubs/lpf2hub.ts
@@ -124,7 +124,7 @@ export class LPF2Hub extends BaseHub {
         }
 
         const len = this._messageBuffer[0];
-        if (len >= this._messageBuffer.length) {
+        if (len <= this._messageBuffer.length) {
 
             const message = this._messageBuffer.slice(0, len);
             this._messageBuffer = this._messageBuffer.slice(len);


### PR DESCRIPTION
I think the expression was wrong: we want to parse if the message length is less or equal to buffer size.
