### PR TITLE
possible fix for #118, always return resolve

### DIFF
--- a/src/devices/absolutemotor.ts
+++ b/src/devices/absolutemotor.ts
@@ -51,7 +51,6 @@ export class AbsoluteMotor extends TachoMotor {
         }
         this.cancelEventTimer();
         return new Promise<void>((resolve) => {
-            this._busy = true;
             if (speed === undefined || speed === null) {
                 speed = 100;
             }
@@ -65,9 +64,9 @@ export class AbsoluteMotor extends TachoMotor {
                 message.writeInt32LE(normalizeAngle(angle), 4);
             }
             this.send(message);
-            this._finished = () => {
+            this._finishedCallbacks.push(() => {
                 return resolve();
-            };
+            });
         });
     }
 

--- a/src/devices/tachomotor.ts
+++ b/src/devices/tachomotor.ts
@@ -104,7 +104,6 @@ export class TachoMotor extends BasicMotor {
         }
         this.cancelEventTimer();
         return new Promise<void>((resolve) => {
-            this._busy = true;
             if (speed === undefined || speed === null) {
                 speed = 100;
             }
@@ -124,9 +123,9 @@ export class TachoMotor extends BasicMotor {
                 }
             }
             this.send(message);
-            this._finished = () => {
+            this._finishedCallbacks.push(() => {
                 return resolve();
-            };
+            });
         });
     }
 
@@ -146,7 +145,6 @@ export class TachoMotor extends BasicMotor {
         }
         this.cancelEventTimer();
         return new Promise<void>((resolve) => {
-            this._busy = true;
             if (speed === undefined || speed === null) {
                 speed = 100;
             }
@@ -158,9 +156,9 @@ export class TachoMotor extends BasicMotor {
             }
             message.writeUInt32LE(degrees, 4);
             this.send(message);
-            this._finished = () => {
+            this._finishedCallbacks.push(() => {
                 return resolve();
-            };
+            });
         });
     }
 

--- a/src/hubs/lpf2hub.ts
+++ b/src/hubs/lpf2hub.ts
@@ -353,10 +353,7 @@ export class LPF2Hub extends BaseHub {
         const device = this._getDeviceByPortId(portId);
 
         if (device) {
-            const finished = (message[4] === 0x0a);
-            if (finished) {
-                device.finish();
-            }
+            device.finish(message[4]);
         }
 
     }


### PR DESCRIPTION
* changed _finished pointer to array to not overwrite callbacks
* all completed and discarded commands get resolved
* 0x10 bitset exists in documentation only? -> not implemented

I have done only a few tests with my technic hubs and motors, but I would expect this to work with all devices. A better solution than this could be to register callbacks for all commands. Then it is possible to only resolve those that completed and reject the discarded ones. For my current project I do not need this, but it might be handy for others.

Below all combinations of feedback bits I managed to produce:

```
    const feedback0x01 = () => { // normal operation, one command in progress sends 0x01 followed by 0x0a when finished
	setInterval(() => {
	    motorA.rotateByDegrees(1,100);
	}, 1000);
    }

    const feedback0x05 = () => { // current command(s) discarded, replaced with new command which is in progress
	setInterval(() => {
            motorA.rotateByDegrees(100,10);
	}, 100);
    }

    const feedback0x0a = () => { // command(s) succeeded
        setInterval(() => {
            motorA.setPower(0);
	}, 100);
    }

    const feedback0x0c = () => { // add some mechanical load to make sure motor is not able to rotate and command fails
        setInterval(() => {
	    motorA.rotateByDegrees(100,1);
        }, 10000);
    }

    const feedback0x0e = () => { // command(s) which were in progress (= rotateByDegrees) discarded, interrupted by new command (= setPower) which succeeded
	setInterval(() => {
            motorA.rotateByDegrees(100,10);
            motorA.setPower(0);
	}, 100);
    }
```




