### PR TITLE
Rename events enum from AlertPayload to Event

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -445,7 +445,7 @@ export enum AlertPayload {
  * @param {number} ATTACHED_VIRTUAL_IO 0x02
  * @description https://lego.github.io/lego-ble-wireless-protocol-docs/index.html#event
  */
-export enum AlertPayload {
+export enum Event {
     DETACHED_IO = 0x00,
     ATTACHED_IO = 0x01,
     ATTACHED_VIRTUAL_IO = 0x02,


### PR DESCRIPTION
Looks like the Event enum got the wrong name, so I've updated it