### PR TITLE
Command feedback

### DIFF
--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -168,6 +168,7 @@ export class Device extends EventEmitter {
     }
 
     public finish (message: number) {
+        if((message & 0x10) === 0x10) return; // "busy/full"
         this._busy = (message & 0x01) === 0x01;
         while(this._finishedCallbacks.length > Number(this._busy)) {
             const callback = this._finishedCallbacks.shift();

--- a/src/hubs/lpf2hub.ts
+++ b/src/hubs/lpf2hub.ts
@@ -348,14 +348,13 @@ export class LPF2Hub extends BaseHub {
 
 
     private _parsePortAction (message: Buffer) {
+        for (let offset = 3; offset < message.length; offset += 2) {
+            const device = this._getDeviceByPortId(message[offset]);
 
-        const portId = message[3];
-        const device = this._getDeviceByPortId(portId);
-
-        if (device) {
-            device.finish(message[4]);
+            if (device) {
+                device.finish(message[offset+1]);
+            }
         }
-
     }
 
 


### PR DESCRIPTION
I found time to find answers to the remaining open questions from 
#118

* feedback for multiple port ids in one message can be obtained when using two motors combined to a virtual port. Stopping an ongoing command for the virtual port by a command to one of its components returns feedback for the virtual port and the individual port in one message.
* the startup and completion bits can be changed to make the command buffer instead of executing immediately or to not request completion feedback
* the 0x10 busy/full feedback can be obtained when dropping the execute immediately bit. Currently you have to use device.send(....) directly for this.

I tested the change with my technic hubs and motors only, but I would expect it to work for all hubs and even if it does not it should not cause any regressions.