### PR TITLE
add workaround for wrong tilt orientation

### DIFF
--- a/src/devices/technicmediumhubtiltsensor.ts
+++ b/src/devices/technicmediumhubtiltsensor.ts
@@ -27,9 +27,17 @@ export class TechnicMediumHubTiltSensor extends Device {
                  * @param {number} y
                  * @param {number} z
                  */
-                const z = -message.readInt16LE(4);
+                let z = -message.readInt16LE(4);
                 const y = message.readInt16LE(6);
                 const x = message.readInt16LE(8);
+
+                // workaround for calibration problem or bug in technicMediumHub firmware 1.1.00.0000
+                if(y === 90 || y === -90) {
+                    z = Math.sign(y)*(z + 180);
+                    if(z > 180) z -= 360;
+                    if(z < -180) z += 360;
+                }
+
                 this.notify("tilt", { x, y, z });
                 break;
         }


### PR DESCRIPTION
Before merging this it would be good if someone else can confirm that they also see the same problem. All my technicmediumhubs have this issue and I can use this workaround to correct it, but it could be that e.g. all my hubs are from some batch that has been put upside down in some factory calibration routine or maybe this is some bug in the firmware that is fixed by lego already and I simply use outdated firmware.

The problem is the following:
If the hub was an airplane, then the z angle of the tilt would be the heading angle. If the airplane flies straight into the ground or straight up, the heading is undefined, one can chose any value. However the roll angle which is x is not undefined, but it depends on the choice of heading angle which defines from what angle to start applying the roll. This is what seems to be wrong in the values the hub reports. In the pull request I chose to correct the heading, one could choose to leave it as is and instead apply the same operation to the x angle.