### PR TITLE
add impact count mode to tiltsensor

### DIFF
--- a/src/devices/technicmediumhubtiltsensor.ts
+++ b/src/devices/technicmediumhubtiltsensor.ts
@@ -10,6 +10,9 @@ import * as Consts from "../consts";
  */
 export class TechnicMediumHubTiltSensor extends Device {
 
+    protected _impactThreshold: number = 10; // guess of default value
+    protected _impactHoldoff: number = 10; // guess of default value
+
     constructor (hub: IDeviceInterface, portId: number) {
         super(hub, portId, ModeMap, Consts.DeviceType.TECHNIC_MEDIUM_HUB_TILT_SENSOR);
     }
@@ -21,26 +24,87 @@ export class TechnicMediumHubTiltSensor extends Device {
             case Mode.TILT:
                 /**
                  * Emits when a tilt sensor is activated.
+                 *
                  * @event TechnicMediumHubTiltSensor#tilt
                  * @type {object}
                  * @param {number} x
                  * @param {number} y
                  * @param {number} z
                  */
-                const z = -message.readInt16LE(4);
+                let z = -message.readInt16LE(4);
                 const y = message.readInt16LE(6);
                 const x = message.readInt16LE(8);
                 this.notify("tilt", { x, y, z });
                 break;
+
+            case Mode.IMPACT_COUNT:
+                if (message.length !== 8) {
+                    // if mode of device has not changed to this._mode yet
+                    break;
+                }
+                const count = message.readUInt32LE(4);
+                /**
+                 * Emits when proper acceleration is above threshold (e.g. on impact when being thrown to the ground).
+                 * @event TechnicMediumHubTiltSensor#impactCount
+                 * @type {object}
+                 * @param {number} number of impact events.
+                 */
+                this.notify("tiltCount", { count });
+                break;
         }
     }
 
+    /**
+     * Set the impact count value.
+     * @method TechnicMediumHubTiltSensor#setImpactCount
+     * @param {count} impact count between 0 and 2^32
+     * @returns {Promise} Resolved upon successful issuance of the command.
+     */
+    public setImpactCount (count: number) {
+        return new Promise<void>((resolve) => {
+            const payload = Buffer.alloc(4);
+	    payload.writeUInt32LE(count % 2**32);
+            // no need to subscribe, can be set in different mode
+            this.writeDirect(0x01, payload);
+            return resolve();
+        });
+    }
+
+    /**
+     * Set the impact threshold.
+     * @method TechnicMediumHubTiltSensor#setImpactThreshold
+     * @param {threshold} value between 1 and 127
+     * @returns {Promise} Resolved upon successful issuance of the command.
+     */
+    public setImpactThreshold (threshold: number) {
+        this._impactThreshold = threshold;
+        return new Promise<void>((resolve) => {
+            this.writeDirect(0x02, Buffer.from([this._impactThreshold, this._impactHoldoff]));
+            return resolve();
+        });
+    }
+
+    /**
+     * Set the impact holdoff time.
+     * @method TechnicMediumHubTiltSensor#setImpactHoldoff
+     * @param {holdoff} value between 1 and 127
+     * @returns {Promise} Resolved upon successful issuance of the command.
+     */
+    public setImpactHoldoff (holdoff: number) {
+        this._impactHoldoff = holdoff;
+        return new Promise<void>((resolve) => {
+            this.writeDirect(0x02, Buffer.from([this._impactThreshold, this._impactHoldoff]));
+            return resolve();
+        });
+    }
 }
 
 export enum Mode {
-    TILT = 0x00
+    TILT = 0x00,
+    IMPACT_COUNT = 0x01
 }
 
 export const ModeMap: {[event: string]: number} = {
-    "tilt": Mode.TILT
+    "tilt": Mode.TILT,
+    "impactCount": Mode.IMPACT_COUNT
 };


### PR DESCRIPTION
This adds some probably rarely required functionality, feel free to decline. 

My problem was that the tilt angle approaching y=90 and y=-90 seems to be inaccurate, e.g. you can see it jumping form y=85 directly to y=90. To verify one can compare to the angle using the acceleration values which I ended up using:

```
    hub.on("accel", (device, { x, y, z }) => {
	const X = Math.round(Math.atan2(y, z)*180/Math.PI);
	const Y = -Math.round(Math.atan2(x, Math.sqrt(y**2 + z**2))*180/Math.PI);
        console.log(`accel (X: ${X}, Y: ${Y}`);
    });
    hub.on("tilt", (device, { x, y, z }) => {
        console.log(`tilt  (X: ${x}, Y: ${y}, Z: ${z}`);
    });
```

My original goal was to configure the orientation like mentioned here https://lego.github.io/lego-ble-wireless-protocol-docs/#output-sub-command-tiltconfigorientation-orientation-n-a. Unfortunately the documentation seems to be outdated and I did not find any up to date one. I was able to set the impact threshold and bump holdoff which I wanted to share in case someone is looking for that or also trying to configure the orientation then it might be of some help.