### PR TITLE
change colordistancesensor distance calculation

### DIFF
--- a/src/devices/colordistancesensor.ts
+++ b/src/devices/colordistancesensor.ts
@@ -63,10 +63,10 @@ export class ColorDistanceSensor extends Device {
                 const partial = message[7];
 
                 if (partial > 0) {
-                    distance += 1.0 / partial;
+                    distance = 1.0 / partial;
                 }
 
-                distance = Math.floor(distance * 25.4) - 20;
+                distance = Math.floor(distance * 25.4);
 
                 /**
                  * A combined color and distance event, emits when the sensor is activated.


### PR DESCRIPTION
I know the distances in general are not very accurate and it depends on the material used for testing how the infrared based distance value and light based partial value combine. But still, with this simplification my overall results were better.