### PR TITLE
rework port output command handling

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -703,3 +703,27 @@ export enum MarioColor {
     BROWN = 0x6a00,
     CYAN = 0x4201,
 }
+
+/**
+ * @typedef CommandFeedback
+ * @param {number} TRANSMISSION_PENDING 0x00 waiting for previous comands to complete transmission or execution
+ * @param {number} TRANSMISSION_BUSY 0x10 waiting for device to acknowledge reception
+ * @param {number} TRANSMISSION_DISCARDED 0x44 other command for immediate execution has been recieved or device disconnected
+ * @param {number} EXECUTION_PENDING 0x20 device is waiting for previous command to complete
+ * @param {number} EXECUTION_BUSY 0x21 device is executing the command
+ * @param {number} EXECUTION_DISCARDED 0x24 device discarded the command e.g. due to other command for immediate execution
+ * @param {number} EXECUTION_COMPLETED 0x22 device reported successful completion of command
+ * @param {number} FEEDBACK_MISSING 0x66 device disconnected or failed to report feedback
+ * @param {number} FEEDBACK_DISABLED 0x26 feedback not implemented for this command
+ */
+export enum CommandFeedback {
+    TRANSMISSION_PENDING = 0x00,
+    TRANSMISSION_BUSY = 0x10,
+    TRANSMISSION_DISCARDED = 0x44,
+    EXECUTION_PENDING = 0x20,
+    EXECUTION_BUSY = 0x21,
+    EXECUTION_DISCARDED = 0x24,
+    EXECUTION_COMPLETED = 0x22,
+    FEEDBACK_MISSING = 0x66,
+    FEEDBACK_DISABLED = 0x26,
+}

--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -1,8 +1,12 @@
 import { EventEmitter } from "events";
 
 import { IDeviceInterface } from "../interfaces";
+import { PortOutputCommand } from "../portoutputcommand";
 
 import * as Consts from "../consts";
+
+import Debug = require("debug");
+const debug = Debug("device");
 
 /**
  * @class Device
@@ -14,8 +18,9 @@ export class Device extends EventEmitter {
     public values: {[event: string]: any} = {};
 
     protected _mode: number | undefined;
-    protected _busy: boolean = false;
-    protected _finishedCallbacks: (() => void)[] = [];
+    protected _bufferLength: number = 0;
+    protected _nextPortOutputCommands: PortOutputCommand[] = [];
+    protected _transmittedPortOutputCommands: PortOutputCommand[] = [];
 
     private _hub: IDeviceInterface;
     private _portId: number;
@@ -126,11 +131,14 @@ export class Device extends EventEmitter {
         return this._isVirtualPort;
     }
 
-    public writeDirect (mode: number, data: Buffer) {
+    public writeDirect (mode: number, data: Buffer, interrupt: boolean = false) {
+        if (interrupt) {
+            this.cancelEventTimer();
+        }
         if (this.isWeDo2SmartHub) {
-            return this.send(Buffer.concat([Buffer.from([this.portId, 0x01, 0x02]), data]), Consts.BLECharacteristic.WEDO2_MOTOR_VALUE_WRITE);
+            return this.send(Buffer.concat([Buffer.from([this.portId, 0x01, 0x02]), data]), Consts.BLECharacteristic.WEDO2_MOTOR_VALUE_WRITE).then(() => { return Consts.CommandFeedback.FEEDBACK_DISABLED; });
         } else {
-            return this.send(Buffer.concat([Buffer.from([0x81, this.portId, 0x11, 0x51, mode]), data]), Consts.BLECharacteristic.LPF2_ALL);
+            return this.sendPortOutputCommand(Buffer.concat([Buffer.from([0x51, mode]), data]), interrupt);
         }
     }
 
@@ -167,15 +175,150 @@ export class Device extends EventEmitter {
         this.send(Buffer.from([0x21, this.portId, 0x00]));
     }
 
-    public finish (message: number) {
-        if((message & 0x10) === 0x10) return; // "busy/full"
-        this._busy = (message & 0x01) === 0x01;
-        while(this._finishedCallbacks.length > Number(this._busy)) {
-            const callback = this._finishedCallbacks.shift();
-            if(callback) {
-                 callback();
+    protected transmitNextPortOutputCommand() {
+        if(!this.connected) {
+            this._transmittedPortOutputCommands.forEach(command => command.resolve(Consts.CommandFeedback.FEEDBACK_MISSING));
+            this._transmittedPortOutputCommands = [];
+            this._nextPortOutputCommands.forEach(command => command.resolve(Consts.CommandFeedback.TRANSMISSION_DISCARDED));
+            this._nextPortOutputCommands = [];
+            return;
+        }
+        if(this._bufferLength !== this._transmittedPortOutputCommands.length) return;
+        if(!this._nextPortOutputCommands.length) return;
+        if(this._bufferLength < 2 || this._nextPortOutputCommands[0].interrupt) {
+            const command = this._nextPortOutputCommands.shift();
+            if(command) {
+                debug("transmit command ", command.startupAndCompletion, command.data);
+                this.send(Buffer.concat([Buffer.from([0x81, this.portId, command.startupAndCompletion]), command.data]));
+                command.state = Consts.CommandFeedback.TRANSMISSION_BUSY;
+                this._transmittedPortOutputCommands.push(command);
+                // one could start a timer here to ensure finish function is called
             }
         }
+    }
+
+    public sendPortOutputCommand(data: Buffer, interrupt: boolean = false) {
+        if (this.isWeDo2SmartHub) {
+            throw new Error("PortOutputCommands are not available on the WeDo 2.0 Smart Hub");
+            return;
+        }
+        const command = new PortOutputCommand(data, interrupt);
+        if(interrupt) {
+            this._nextPortOutputCommands.forEach(command => command.resolve(Consts.CommandFeedback.TRANSMISSION_DISCARDED));
+            this._nextPortOutputCommands = [ command ];
+        }
+        else {
+            this._nextPortOutputCommands.push(command);
+        }
+        this.transmitNextPortOutputCommand();
+        return command.promise;
+    }
+
+    public finish (message: number) {
+        debug("recieved command feedback ", message);
+        if((message & 0x08) === 0x08) this._bufferLength = 0;
+        else if((message & 0x01) === 0x01) this._bufferLength = 1;
+        else if((message & 0x10) === 0x10) this._bufferLength = 2;
+        const completed = ((message & 0x02) === 0x02);
+        const discarded = ((message & 0x04) === 0x04);
+
+        switch(this._transmittedPortOutputCommands.length) {
+            case 0:
+                break;
+            case 1:
+                if(!this._bufferLength && completed && !discarded) {
+                    this._complete();
+                }
+                else if(!this._bufferLength && !completed && discarded) {
+                    this._discard();
+                }
+                else if(this._bufferLength && !completed && !discarded) {
+                    this._busy();
+                }
+                else {
+                    this._missing();
+                }
+                break;
+            case 2:
+                if(!this._bufferLength && completed && discarded) {
+                    this._discard();
+                    this._complete();
+                }
+                else if(!this._bufferLength && completed && !discarded) {
+                    this._complete();
+                    this._complete();
+                }
+                else if(!this._bufferLength && !completed && discarded) {
+                    this._discard();
+                    this._discard();
+                }
+                else if(this._bufferLength === 1 && completed && !discarded) {
+                    this._complete();
+                    this._busy();
+                }
+                else if(this._bufferLength === 1 && !completed && discarded) {
+                    this._discard();
+                    this._busy();
+                }
+                else if(this._bufferLength === 1 && completed && discarded) {
+                    this._missing();
+                    this._busy();
+                }
+                else if(this._bufferLength === 2 && !completed && !discarded) {
+                    this._busy();
+                    this._pending();
+                }
+                else {
+                    this._missing();
+                    this._missing();
+                }
+                break;
+            case 3:
+                if(!this._bufferLength && completed && discarded) {
+                    this._discard();
+                    this._discard();
+                    this._complete();
+                }
+                else if(!this._bufferLength && completed && !discarded) {
+                    this._complete();
+                    this._complete();
+                    this._complete();
+                }
+                else if(!this._bufferLength && !completed && discarded) {
+                    this._discard();
+                    this._discard();
+                    this._discard();
+                }
+                else if(this._bufferLength === 1 && completed && discarded) {
+                    this._discard();
+                    this._complete();
+                    this._busy();
+                }
+                else if(this._bufferLength === 1 && completed && !discarded) {
+                    this._complete();
+                    this._complete();
+                    this._busy();
+                }
+                else if(this._bufferLength === 1 && !completed && discarded) {
+                    this._discard();
+                    this._discard();
+                    this._busy();
+                }
+                else if(this._bufferLength === 1 && !completed && !discarded) {
+                    this._missing();
+                    this._missing();
+                    this._busy();
+                }
+                // third command can only be interrupt, if busy === 2 it was queued
+                else {
+                    this._missing();
+                    this._missing();
+                    this._missing();
+                }
+                break;
+        }
+
+        this.transmitNextPortOutputCommand();
     }
 
     public setEventTimer (timer: NodeJS.Timer) {
@@ -195,4 +338,24 @@ export class Device extends EventEmitter {
         }
     }
 
+    private _complete () {
+        const command = this._transmittedPortOutputCommands.shift();
+        if(command) command.resolve(Consts.CommandFeedback.EXECUTION_COMPLETED);
+    }
+    private _discard () {
+        const command = this._transmittedPortOutputCommands.shift();
+        if(command) command.resolve(Consts.CommandFeedback.EXECUTION_DISCARDED);
+    }
+    private _missing () {
+        const command = this._transmittedPortOutputCommands.shift();
+        if(command) command.resolve(Consts.CommandFeedback.FEEDBACK_MISSING);
+    }
+    private _busy () {
+        const command = this._transmittedPortOutputCommands[0];
+        if(command) command.state = Consts.CommandFeedback.EXECUTION_BUSY;
+    }
+    private _pending () {
+        const command = this._transmittedPortOutputCommands[1];
+        if(command) command.state = Consts.CommandFeedback.EXECUTION_PENDING;
+    }
 }

--- a/src/devices/duplotrainbasespeaker.ts
+++ b/src/devices/duplotrainbasespeaker.ts
@@ -18,25 +18,22 @@ export class DuploTrainBaseSpeaker extends Device {
      * Play a built-in train sound.
      * @method DuploTrainBaseSpeaker#playSound
      * @param {DuploTrainBaseSound} sound
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command.
      */
     public playSound (sound: Consts.DuploTrainBaseSound) {
-        return new Promise<void>((resolve) => {
-            this.subscribe(Mode.SOUND);
-            this.writeDirect(0x01, Buffer.from([sound]));
-            return resolve();
-        });
+        this.subscribe(Mode.SOUND);
+        return this.writeDirect(0x01, Buffer.from([sound]));
     }
 
     /**
      * Play a built-in system tone.
      * @method DuploTrainBaseSpeaker#playTone
      * @param {number} tone
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command.
      */
     public playTone (tone: number) {
         this.subscribe(Mode.TONE);
-        this.writeDirect(0x02, Buffer.from([tone]));
+        return this.writeDirect(0x02, Buffer.from([tone]));
     }
 
 }

--- a/src/devices/hubled.ts
+++ b/src/devices/hubled.ts
@@ -20,22 +20,22 @@ export class HubLED extends Device {
      * Set the color of the LED on the Hub via a color value.
      * @method HubLED#setColor
      * @param {Color} color
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command.
      */
     public setColor (color: number | boolean) {
-        return new Promise<void>((resolve) => {
-            if (typeof color === "boolean") {
-                color = 0;
-            }
-            if (this.isWeDo2SmartHub) {
+        if (typeof color === "boolean") {
+            color = 0;
+        }
+        if (this.isWeDo2SmartHub) {
+            return new Promise<Consts.CommandFeedback>((resolve) => {
                 this.send(Buffer.from([0x06, 0x17, 0x01, 0x01]), Consts.BLECharacteristic.WEDO2_PORT_TYPE_WRITE);
-                this.send(Buffer.from([0x06, 0x04, 0x01, color]), Consts.BLECharacteristic.WEDO2_MOTOR_VALUE_WRITE);
-            } else {
-                this.subscribe(Mode.COLOR);
-                this.writeDirect(0x00, Buffer.from([color]));
-            }
-            return resolve();
-        });
+                this.send(Buffer.from([0x06, 0x04, 0x01, Number(color)]), Consts.BLECharacteristic.WEDO2_MOTOR_VALUE_WRITE);
+                return resolve(Consts.CommandFeedback.FEEDBACK_DISABLED);
+            })
+        } else {
+            this.subscribe(Mode.COLOR);
+            return this.writeDirect(0x00, Buffer.from([color]));
+        }
     }
 
 
@@ -45,19 +45,19 @@ export class HubLED extends Device {
      * @param {number} red
      * @param {number} green
      * @param {number} blue
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command.
      */
     public setRGB (red: number, green: number, blue: number) {
-        return new Promise<void>((resolve) => {
-            if (this.isWeDo2SmartHub) {
+        if (this.isWeDo2SmartHub) {
+            return new Promise<Consts.CommandFeedback>((resolve) => {
                 this.send(Buffer.from([0x06, 0x17, 0x01, 0x02]), Consts.BLECharacteristic.WEDO2_PORT_TYPE_WRITE);
                 this.send(Buffer.from([0x06, 0x04, 0x03, red, green, blue]), Consts.BLECharacteristic.WEDO2_MOTOR_VALUE_WRITE);
-            } else {
-                this.subscribe(Mode.RGB);
-                this.writeDirect(0x01, Buffer.from([red, green, blue]));
-            }
-            return resolve();
-        });
+                resolve(Consts.CommandFeedback.FEEDBACK_DISABLED);
+            });
+        } else {
+            this.subscribe(Mode.RGB);
+            return this.writeDirect(0x01, Buffer.from([red, green, blue]));
+        }
     }
 
 

--- a/src/devices/piezobuzzer.ts
+++ b/src/devices/piezobuzzer.ts
@@ -21,15 +21,15 @@ export class PiezoBuzzer extends Device {
      * @method PiezoBuzzer#playTone
      * @param {number} frequency
      * @param {number} time How long the tone should play for (in milliseconds).
-     * @returns {Promise} Resolved upon successful completion of command (ie. once the tone has finished playing).
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command (ie. once the tone has finished playing).
      */
     public playTone (frequency: number, time: number) {
-        return new Promise((resolve) => {
+        return new Promise<Consts.CommandFeedback>((resolve) => {
             const data = Buffer.from([0x05, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00]);
             data.writeUInt16LE(frequency, 3);
             data.writeUInt16LE(time, 5);
             this.send(data, Consts.BLECharacteristic.WEDO2_MOTOR_VALUE_WRITE);
-            global.setTimeout(resolve, time);
+            global.setTimeout(() => {return resolve(Consts.CommandFeedback.FEEDBACK_DISABLED)}, time);
         });
     }
 

--- a/src/devices/tachomotor.ts
+++ b/src/devices/tachomotor.ts
@@ -66,12 +66,14 @@ export class TachoMotor extends BasicMotor {
      * Set the global acceleration time
      * @method TachoMotor#setAccelerationTime
      * @param {number} time How long acceleration should last (in milliseconds).
-     * @returns {Promise} Resolved upon successful completion of command (ie. once the motor is finished).
+     * @param {number} profile 0 by default
+     * @param {boolean} interrupt If true, previous commands are discarded.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command (ie. once the motor is finished).
      */
-    public setAccelerationTime (time: number, profile: number = 0x00) {
-        const message = Buffer.from([0x81, this.portId, 0x11, 0x05, 0x00, 0x00, profile]);
-        message.writeUInt16LE(time, 4);
-        this.send(message);
+    public setAccelerationTime (time: number, profile: number = 0x00, interrupt: boolean = false) {
+        const message = Buffer.from([0x05, 0x00, 0x00, profile]);
+        message.writeUInt16LE(time, 1);
+        return this.sendPortOutputCommand(message, interrupt);
     }
 
 
@@ -79,12 +81,14 @@ export class TachoMotor extends BasicMotor {
      * Set the global deceleration time
      * @method TachoMotor#setDecelerationTime
      * @param {number} time How long deceleration should last (in milliseconds).
-     * @returns {Promise} Resolved upon successful completion of command (ie. once the motor is finished).
+     * @param {number} profile 0 by default
+     * @param {boolean} interrupt If true, previous commands are discarded.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command (ie. once the motor is finished).
      */
-    public setDecelerationTime (time: number, profile: number = 0x00) {
-        const message = Buffer.from([0x81, this.portId, 0x11, 0x06, 0x00, 0x00, profile]);
-        message.writeUInt16LE(time, 4);
-        this.send(message);
+    public setDecelerationTime (time: number, profile: number = 0x00, interrupt: boolean = true) {
+        const message = Buffer.from([0x06, 0x00, 0x00, profile]);
+        message.writeUInt16LE(time, 1);
+        return this.sendPortOutputCommand(message, interrupt);
     }
 
 
@@ -93,40 +97,35 @@ export class TachoMotor extends BasicMotor {
      * @method TachoMotor#setSpeed
      * @param {number} speed For forward, a value between 1 - 100 should be set. For reverse, a value between -1 to -100. Stop is 0.
      * @param {number} time How long the motor should run for (in milliseconds).
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @param {boolean} interrupt If true, previous commands are discarded.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command (ie. once the motor is finished).
      */
-    public setSpeed (speed: [number, number] | number, time: number | undefined) {
+    public setSpeed (speed: [number, number] | number, time: number | undefined, interrupt: boolean = false) {
         if (!this.isVirtualPort && speed instanceof Array) {
             throw new Error("Only virtual ports can accept multiple speeds");
         }
         if (this.isWeDo2SmartHub) {
             throw new Error("Motor speed is not available on the WeDo 2.0 Smart Hub");
         }
-        this.cancelEventTimer();
-        return new Promise<void>((resolve) => {
-            if (speed === undefined || speed === null) {
-                speed = 100;
-            }
-            let message;
-            if (time !== undefined) {
-                if (speed instanceof Array) {
-                    message = Buffer.from([0x81, this.portId, 0x11, 0x0a, 0x00, 0x00, mapSpeed(speed[0]), mapSpeed(speed[1]), this._maxPower, this._brakeStyle, this.useProfile()]);
-                } else {
-                    message = Buffer.from([0x81, this.portId, 0x11, 0x09, 0x00, 0x00, mapSpeed(speed), this._maxPower, this._brakeStyle, this.useProfile()]);
-                }
-                message.writeUInt16LE(time, 4);
+        if (speed === undefined || speed === null) {
+            speed = 100;
+        }
+        let message;
+        if (time !== undefined) {
+            if (speed instanceof Array) {
+                message = Buffer.from([0x0a, 0x00, 0x00, mapSpeed(speed[0]), mapSpeed(speed[1]), this._maxPower, this._brakeStyle, this.useProfile()]);
             } else {
-                if (speed instanceof Array) {
-                    message = Buffer.from([0x81, this.portId, 0x11, 0x08, mapSpeed(speed[0]), mapSpeed(speed[1]), this._maxPower, this.useProfile()]);
-                } else {
-                    message = Buffer.from([0x81, this.portId, 0x11, 0x07, mapSpeed(speed), this._maxPower, this.useProfile()]);
-                }
+                message = Buffer.from([0x09, 0x00, 0x00, mapSpeed(speed), this._maxPower, this._brakeStyle, this.useProfile()]);
             }
-            this.send(message);
-            this._finishedCallbacks.push(() => {
-                return resolve();
-            });
-        });
+            message.writeUInt16LE(time, 1);
+        } else {
+            if (speed instanceof Array) {
+                message = Buffer.from([0x08, mapSpeed(speed[0]), mapSpeed(speed[1]), this._maxPower, this.useProfile()]);
+            } else {
+                message = Buffer.from([0x07, mapSpeed(speed), this._maxPower, this.useProfile()]);
+            }
+        }
+        return this.sendPortOutputCommand(message, interrupt);
     }
 
     /**
@@ -134,32 +133,27 @@ export class TachoMotor extends BasicMotor {
      * @method TachoMotor#rotateByDegrees
      * @param {number} degrees How much the motor should be rotated (in degrees).
      * @param {number} [speed=100] For forward, a value between 1 - 100 should be set. For reverse, a value between -1 to -100.
-     * @returns {Promise} Resolved upon successful completion of command (ie. once the motor is finished).
+     * @param {boolean} interrupt If true, previous commands are discarded.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command (ie. once the motor is finished).
      */
-    public rotateByDegrees (degrees: number, speed: [number, number] | number) {
+    public rotateByDegrees (degrees: number, speed: [number, number] | number, interrupt: boolean = false) {
         if (!this.isVirtualPort && speed instanceof Array) {
             throw new Error("Only virtual ports can accept multiple speeds");
         }
         if (this.isWeDo2SmartHub) {
             throw new Error("Rotation is not available on the WeDo 2.0 Smart Hub");
         }
-        this.cancelEventTimer();
-        return new Promise<void>((resolve) => {
-            if (speed === undefined || speed === null) {
-                speed = 100;
-            }
-            let message;
-            if (speed instanceof Array) {
-                message = Buffer.from([0x81, this.portId, 0x11, 0x0c, 0x00, 0x00, 0x00, 0x00, mapSpeed(speed[0]), mapSpeed(speed[1]), this._maxPower, this._brakeStyle, this.useProfile()]);
-            } else {
-                message = Buffer.from([0x81, this.portId, 0x11, 0x0b, 0x00, 0x00, 0x00, 0x00, mapSpeed(speed), this._maxPower, this._brakeStyle, this.useProfile()]);
-            }
-            message.writeUInt32LE(degrees, 4);
-            this.send(message);
-            this._finishedCallbacks.push(() => {
-                return resolve();
-            });
-        });
+        if (speed === undefined || speed === null) {
+            speed = 100;
+        }
+        let message;
+        if (speed instanceof Array) {
+            message = Buffer.from([0x0c, 0x00, 0x00, 0x00, 0x00, mapSpeed(speed[0]), mapSpeed(speed[1]), this._maxPower, this._brakeStyle, this.useProfile()]);
+        } else {
+            message = Buffer.from([0x0b, 0x00, 0x00, 0x00, 0x00, mapSpeed(speed), this._maxPower, this._brakeStyle, this.useProfile()]);
+        }
+        message.writeUInt32LE(degrees, 1);
+        return this.sendPortOutputCommand(message, interrupt);
     }
 
 

--- a/src/devices/technic3x3colorlightmatrix.ts
+++ b/src/devices/technic3x3colorlightmatrix.ts
@@ -22,35 +22,32 @@ export class Technic3x3ColorLightMatrix extends Device {
      * Set the LED matrix, one color per LED
      * @method Technic3x3ColorLightMatrix#setMatrix
      * @param {Color[] | Color} colors Array of 9 colors, 9 Color objects, or a single color
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of command.
      */
     public setMatrix (colors: number[] | number) {
-        return new Promise<void>((resolve) => {
-            this.subscribe(Mode.PIX_0);
-            const colorArray = new Array(9);
-            for (let i = 0; i < colorArray.length; i++) {
-                if (typeof colors ===  'number') {
-                    // @ts-ignore
-                    colorArray[i] = colors + (10 << 4);
-                }
+        this.subscribe(Mode.PIX_0);
+        const colorArray = new Array(9);
+        for (let i = 0; i < colorArray.length; i++) {
+            if (typeof colors ===  'number') {
                 // @ts-ignore
-                if (colors[i] instanceof Color) {
-                    // @ts-ignore
-                    colorArray[i] = colors[i].toValue();
-                }
-                // @ts-ignore
-                if (colors[i] === Consts.Color.NONE) {
-                    colorArray[i] = Consts.Color.NONE;
-                }
-                // @ts-ignore
-                if (colors[i] <= 10) {
-                    // @ts-ignore
-                    colorArray[i] = colors[i] + (10 << 4); // If a raw color value, set it to max brightness (10)
-                }
+                colorArray[i] = colors + (10 << 4);
             }
-            this.writeDirect(Mode.PIX_0, Buffer.from(colorArray));
-            return resolve();
-        });
+            // @ts-ignore
+            if (colors[i] instanceof Color) {
+                // @ts-ignore
+                colorArray[i] = colors[i].toValue();
+            }
+            // @ts-ignore
+            if (colors[i] === Consts.Color.NONE) {
+                colorArray[i] = Consts.Color.NONE;
+            }
+            // @ts-ignore
+            if (colors[i] <= 10) {
+                // @ts-ignore
+                colorArray[i] = colors[i] + (10 << 4); // If a raw color value, set it to max brightness (10)
+            }
+        }
+        return this.writeDirect(Mode.PIX_0, Buffer.from(colorArray));
     }
 
 

--- a/src/devices/techniccolorsensor.ts
+++ b/src/devices/techniccolorsensor.ts
@@ -65,10 +65,10 @@ export class TechnicColorSensor extends Device {
      * @param {number} firstSegment First light segment. 0-100 brightness.
      * @param {number} secondSegment Second light segment. 0-100 brightness.
      * @param {number} thirdSegment Third light segment. 0-100 brightness.
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of the command.
      */
     public setBrightness (firstSegment: number, secondSegment: number, thirdSegment: number) {
-        this.writeDirect(0x03, Buffer.from([firstSegment, secondSegment, thirdSegment]));
+        return this.writeDirect(0x03, Buffer.from([firstSegment, secondSegment, thirdSegment]));
     }
 
 }

--- a/src/devices/technicdistancesensor.ts
+++ b/src/devices/technicdistancesensor.ts
@@ -51,7 +51,7 @@ export class TechnicDistanceSensor extends Device {
      * @param {number} bottomLeft Bottom left quadrant (below left eye). 0-100 brightness.
      * @param {number} topRight Top right quadrant (above right eye). 0-100 brightness.
      * @param {number} bottomRight Bottom right quadrant (below right eye). 0-100 brightness.
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of the command.
      */
     public setBrightness (topLeft: number, bottomLeft: number, topRight: number, bottomRight: number) {
         this.writeDirect(0x05, Buffer.from([topLeft, topRight, bottomLeft, bottomRight]));

--- a/src/devices/technicmediumhubtiltsensor.ts
+++ b/src/devices/technicmediumhubtiltsensor.ts
@@ -66,44 +66,35 @@ export class TechnicMediumHubTiltSensor extends Device {
      * Set the impact count value.
      * @method TechnicMediumHubTiltSensor#setImpactCount
      * @param {count} impact count between 0 and 2^32
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of the command.
      */
     public setImpactCount (count: number) {
-        return new Promise<void>((resolve) => {
-            const payload = Buffer.alloc(4);
-	    payload.writeUInt32LE(count % 2**32);
-            // no need to subscribe, can be set in different mode
-            this.writeDirect(0x01, payload);
-            return resolve();
-        });
+        const payload = Buffer.alloc(4);
+        payload.writeUInt32LE(count % 2**32);
+        // no need to subscribe, can be set in different mode
+        return this.writeDirect(0x01, payload);
     }
 
     /**
      * Set the impact threshold.
      * @method TechnicMediumHubTiltSensor#setImpactThreshold
      * @param {threshold} value between 1 and 127
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of the command.
      */
     public setImpactThreshold (threshold: number) {
         this._impactThreshold = threshold;
-        return new Promise<void>((resolve) => {
-            this.writeDirect(0x02, Buffer.from([this._impactThreshold, this._impactHoldoff]));
-            return resolve();
-        });
+        return this.writeDirect(0x02, Buffer.from([this._impactThreshold, this._impactHoldoff]));
     }
 
     /**
      * Set the impact holdoff time.
      * @method TechnicMediumHubTiltSensor#setImpactHoldoff
      * @param {holdoff} value between 1 and 127
-     * @returns {Promise} Resolved upon successful issuance of the command.
+     * @returns {Promise<CommandFeedback>} Resolved upon completion of the command.
      */
     public setImpactHoldoff (holdoff: number) {
         this._impactHoldoff = holdoff;
-        return new Promise<void>((resolve) => {
-            this.writeDirect(0x02, Buffer.from([this._impactThreshold, this._impactHoldoff]));
-            return resolve();
-        });
+        return this.writeDirect(0x02, Buffer.from([this._impactThreshold, this._impactHoldoff]));
     }
 }
 

--- a/src/portoutputcommand.ts
+++ b/src/portoutputcommand.ts
@@ -1,0 +1,37 @@
+import { CommandFeedback } from "./consts";
+import Debug = require("debug");
+const debug = Debug("device");
+
+export class PortOutputCommand {
+
+    public data: Buffer;
+    public interrupt: boolean;
+    public state: CommandFeedback;
+    private _promise: Promise<CommandFeedback>;
+    private _resolveCallback: any;
+
+    constructor (data: Buffer, interrupt: boolean) {
+        this.data = data;
+        this.interrupt = interrupt;
+        this.state = CommandFeedback.TRANSMISSION_PENDING;
+        this._promise = new Promise<CommandFeedback>((resolve) => {
+            this._resolveCallback = () => resolve(this.state);
+        });
+    }
+
+    public get startupAndCompletion () {
+        let val = 0x01; // request feedback
+        if(this.interrupt) val |= 0x10;
+        return val;
+    }
+
+    public get promise () {
+        return this._promise;
+    }
+
+    public resolve(feedback: CommandFeedback) {
+        debug("complete command ", this.startupAndCompletion, this.data, " result: ", feedback);
+        this.state = feedback;
+        this._resolveCallback();
+    }
+}


### PR DESCRIPTION
Initially I only planned to do some small improvements to prevent my port input commands from clogging up such that they were already outdated when being transmitted. But the whole undertaking got more and more inconsistent and messy, so I ended up doing a large-scale rework for all port output commands.

A large majority of code using the library should be compatible with the changes, but some things would change. Rough overview of most important breaking change without paying attention to detail:

**same behavior:**
`motorA.rotateByDegrees(30).then(motorA.rotateByDegrees(30));`
Result: motorA rotates by 60 degrees in total

`await motorA.rotateByDegrees(30);
 await motorA.rotateByDegrees(30);`
Result: motorA rotates by 60 degrees in total

`motorA.rotateByDegrees(30);
 motorB.rotateByDegrees(30);`
Result: motorA and motorB start rotating at the same time by 30 degrees each

`motorA.setAccelerationTime(300);
 motorA.rotateByDegrees(30);`
Result: the acceleration time is set to 300 ms and then motorA rotates by 30 degrees

**different behavior:**
`motorA.rotateByDegrees(30);
 motorA.rotateByDegrees(30);`
Result old: motorA rotates by 30 degrees
Result new: motorA rotates by 60 degrees

**new feature:**
`motorA.rotateByDegrees(90);
 motorA.rotateByDegrees(30, true);`
Result new: motorA rotates by 30 degrees. 

I tested with a technic hub and two motors so far it works great for me and I did not encounter any problems, therefore I decided to put this change up for discussion even though not every device has been tested.

Commit message:
use explicit queues for port output commands;
this helps the device to remain responsive by preventing old port
output commands from clogging the bluetooth transmission.

add improved interrupt property;
if true, ALL previous commands are discarded
if false, NONE of the previous commands are discarded
this changes the previous behavior where commands queued for
transmission could not be discarded and transmitted commands
would not wait for the device to complete the previous command.

send commands to queue by default (except break and stop);
this keeps and improves the ability to accept commands faster than
they can be transmitted via bluetooth and ensures that no commands
discard previous commands in case they are not explicitly chained.

provide feedback about success of commands.