### PR TITLE
Basic implementation to support pybricks hubs

### DIFF
--- a/examples/pybricks_inventorhub.js
+++ b/examples/pybricks_inventorhub.js
@@ -1,0 +1,32 @@
+/*
+ *
+ * This demonstrates connecting a Spike Prime / Mindstorms Inventor Hub with pybricks firmware.
+ *
+ */
+
+const PoweredUP = require("..");
+
+const poweredUP = new PoweredUP.PoweredUP();
+poweredUP.scan(); // Start scanning for hubs
+
+console.log("Looking for Hubs...");
+
+poweredUP.on("discover", async (hub) => { // Wait to discover hubs
+    if(hub.type === PoweredUP.Consts.HubType.PYBRICKS_HUB) {
+        await hub.connect(); // If we found a hub with Pybricks firmware, connect to it
+        console.log(`Connected to ${hub.name}!`);
+
+        // If the hub transmits something, show it in the console
+        hub.on("recieve", (data) => { console.log(data.toString()) });
+
+        hub.stopUserProgram(); // Stop any running user program
+        // The hub is now waiting for a user program to be uploaded which will then get executed
+
+        hub.startUserProgram(`
+from pybricks.hubs import InventorHub
+hub = InventorHub() # We assume the connected hub is an Inventor hub
+hub.display.text("Hello node-poweredup!") # Show on the led matrix of the hub
+print("finished") # Transmit via bluetooth to the laptop
+        `);
+    }
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@abandonware/noble": "1.9.2-15",
     "compare-versions": "^4.1.3",
-    "debug": "^4.3.3"
+    "debug": "^4.3.3",
+    "@pybricks/mpy-cross-v6": "^2.0.0"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -9,6 +9,7 @@
  * @property {number} TECHNIC_MEDIUM_HUB 6
  * @property {number} MARIO 7
  * @property {number} TECHNIC_SMALL_HUB 8
+ * @property {number} PYBRICKS_HUB 100
  */
 export enum HubType {
     UNKNOWN = 0,
@@ -20,6 +21,7 @@ export enum HubType {
     TECHNIC_MEDIUM_HUB = 6,
     MARIO = 7,
     TECHNIC_SMALL_HUB = 8,
+    PYBRICKS_HUB = 100,
 }
 
 
@@ -215,7 +217,9 @@ export enum BLEService {
     WEDO2_SMART_HUB_3 = "2a19",
     WEDO2_SMART_HUB_4 = "180f",
     WEDO2_SMART_HUB_5 = "180a",
-    LPF2_HUB = "00001623-1212-efde-1623-785feabcd123"
+    LPF2_HUB = "00001623-1212-efde-1623-785feabcd123",
+    PYBRICKS_HUB = "c5f50001-8280-46da-89f4-6d8051e4aeef",
+    PYBRICKS_NUS = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
 }
 
 
@@ -233,7 +237,10 @@ export enum BLECharacteristic {
     WEDO2_PORT_TYPE_WRITE = "00001563-1212-efde-1523-785feabcd123", // "1563"
     WEDO2_MOTOR_VALUE_WRITE = "00001565-1212-efde-1523-785feabcd123", // "1565"
     WEDO2_NAME_ID = "00001524-1212-efde-1523-785feabcd123", // "1524"
-    LPF2_ALL = "00001624-1212-efde-1623-785feabcd123"
+    LPF2_ALL = "00001624-1212-efde-1623-785feabcd123",
+    PYBRICKS_CONTROL = "c5f50002-8280-46da-89f4-6d8051e4aeef",
+    PYBRICKS_NUS_RX = "6e400002-b5a3-f393-e0a9-e50e24dcca9e",
+    PYBRICKS_NUS_TX = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
 }
 
 

--- a/src/hubs/pybrickshub.ts
+++ b/src/hubs/pybrickshub.ts
@@ -1,0 +1,95 @@
+import { Peripheral } from "@abandonware/noble";
+import { compile } from "@pybricks/mpy-cross-v6";
+import { IBLEAbstraction } from "../interfaces";
+import { BaseHub } from "./basehub";
+import * as Consts from "../consts";
+import Debug = require("debug");
+const debug = Debug("pybrickshub");
+
+
+/**
+ * The PybricksHub is emitted if the discovered device is hub with pybricks firmware.
+ * @class PybricksHub
+ * @extends BaseHub
+ */
+export class PybricksHub extends BaseHub {
+    private _checkSumCallback: ((buffer: Buffer) => any) | undefined;
+
+    public static IsPybricksHub (peripheral: Peripheral) {
+        return (
+            peripheral.advertisement &&
+            peripheral.advertisement.serviceUuids &&
+            peripheral.advertisement.serviceUuids.indexOf(Consts.BLEService.PYBRICKS_HUB.replace(/-/g, "")) >= 0
+        );
+    }
+
+
+    constructor (device: IBLEAbstraction) {
+        super(device, PortMap, Consts.HubType.PYBRICKS_HUB);
+        debug("Discovered Pybricks Hub");
+    }
+
+
+    public connect () {
+        return new Promise<void>(async (resolve) => {
+            debug("Connecting to Pybricks Hub");
+            await super.connect();
+            await this._bleDevice.discoverCharacteristicsForService(Consts.BLEService.PYBRICKS_HUB);
+            await this._bleDevice.discoverCharacteristicsForService(Consts.BLEService.PYBRICKS_NUS);
+            debug("Connect completed");
+            this.emit("connect");
+            resolve();
+            this._bleDevice.subscribeToCharacteristic(Consts.BLECharacteristic.PYBRICKS_NUS_TX, this._parseMessage.bind(this));
+        });
+    }
+
+    private _parseMessage (data?: Buffer) {
+        debug("Received Message (PYBRICKS_NUS_TX)", data);
+        if(this._checkSumCallback && data) {
+            return this._checkSumCallback(data);
+        }
+        this.emit("recieve", data);
+    }
+
+    public send (message: Buffer, uuid: string = Consts.BLECharacteristic.PYBRICKS_NUS_RX) {
+        debug(`Send Message (${uuid})`,  message);
+        return this._bleDevice.writeToCharacteristic(uuid, message);
+    }
+
+    public startUserProgram (pythonCode: string) {
+        debug("Compiling Python User Program", pythonCode);
+        return compile("UserProgram.py", pythonCode).then(async (result) => {
+            if(result.mpy) {
+                debug("Uploading Python User Program", result.mpy);
+                const programLength = Buffer.alloc(4);
+                programLength.writeUint32LE(result.mpy.byteLength);
+                const checkSumPromise = new Promise<boolean>((resolve) => {
+                    const checkSum = programLength.reduce((a, b) => a ^ b);
+                    this._checkSumCallback = (data) => resolve(data[0] === checkSum);
+                });
+                this.send(programLength, Consts.BLECharacteristic.PYBRICKS_NUS_RX);
+                await checkSumPromise;
+                const chunkSize = 100;
+                for (let i = 0; i < result.mpy.byteLength; i += chunkSize) {
+                    const chunk = result.mpy.slice(i, i + chunkSize);
+                    const checkSumPromise = new Promise<boolean>((resolve) => {
+                        const checkSum = chunk.reduce((a, b) => a ^ b);
+                        this._checkSumCallback = (data) => resolve(data[0] === checkSum);
+                    });
+                    this.send(Buffer.from(chunk), Consts.BLECharacteristic.PYBRICKS_NUS_RX);
+                    await checkSumPromise;
+                }
+                this._checkSumCallback = undefined;
+                debug("Finished uploading");
+            }
+            else throw new Error(`Compiling Python User Program failed: ${result.err}`);
+        });
+    }
+
+    public stopUserProgram () {
+        return this.send(Buffer.from([0]), Consts.BLECharacteristic.PYBRICKS_CONTROL);
+    }
+}
+
+export const PortMap: {[portName: string]: number} = {
+};

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -11,6 +11,7 @@ import { MoveHub } from "./hubs/movehub";
 import { RemoteControl } from "./hubs/remotecontrol";
 import { TechnicMediumHub } from "./hubs/technicmediumhub";
 import { WeDo2SmartHub } from "./hubs/wedo2smarthub";
+import { PybricksHub } from "./hubs/pybrickshub";
 
 import { ColorDistanceSensor } from "./devices/colordistancesensor";
 import { CurrentSensor } from "./devices/currentsensor";
@@ -58,6 +59,7 @@ export {
     Hub,
     RemoteControl,
     DuploTrainBase,
+    PybricksHub,
     Consts,
     Color,
     ColorDistanceSensor,

--- a/src/poweredup-node.ts
+++ b/src/poweredup-node.ts
@@ -10,6 +10,7 @@ import { MoveHub } from "./hubs/movehub";
 import { RemoteControl } from "./hubs/remotecontrol";
 import { TechnicMediumHub } from "./hubs/technicmediumhub";
 import { WeDo2SmartHub } from "./hubs/wedo2smarthub";
+import { PybricksHub } from "./hubs/pybrickshub";
 
 import * as Consts from "./consts";
 
@@ -25,6 +26,8 @@ let wantScan = false;
 
 const startScanning = () => {
     noble.startScanning([
+        Consts.BLEService.PYBRICKS_HUB,
+        Consts.BLEService.PYBRICKS_HUB.replace(/-/g, ""),
         Consts.BLEService.LPF2_HUB,
         Consts.BLEService.LPF2_HUB.replace(/-/g, ""),
         Consts.BLEService.WEDO2_SMART_HUB,
@@ -172,6 +175,8 @@ export class PoweredUP extends EventEmitter {
             hub = new TechnicMediumHub(device);
         } else if (Mario.IsMario(peripheral)) {
             hub = new Mario(device);
+        } else if (PybricksHub.IsPybricksHub(peripheral)) {
+            hub = new PybricksHub(device);
         } else {
             return;
         }


### PR DESCRIPTION
This commit adds a new hub type: PybricksHub. To use the new hub,
you need to have Pybricks firmware installed on your hub, see
https://pybricks.com for further instructions.

For now, the hub is only available in the Node.js, not in the Web-
Bluetooth implementation. Properties like firmware version are not
implemented yet. You can connect, compile, upload and run Python code
and send and recieve data via NUS with one connected Pybricks hub
at a time.